### PR TITLE
Update Builder.io model from page to EngageX

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1,269 +1,54 @@
-"use client";
+useEffect(() => {
+  // Check environment and API key
+  const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
 
-import { useEffect, useState } from "react";
-import { builder, BuilderComponent } from "@builder.io/react";
+  setDebugInfo({
+    hasApiKey: !!apiKey,
+    apiKeyLength: apiKey?.length || 0,
+    nodeEnv: process.env.NODE_ENV,
+    builderInitialized: !!builder.apiKey,
+  });
 
-export default function ObservationForm() {
-  const [allPages, setAllPages] = useState<any[]>([]);
-  const [selectedContent, setSelectedContent] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [debugInfo, setDebugInfo] = useState<any>({});
+  // Initialize Builder if not already done
+  if (!builder.apiKey && apiKey) {
+    builder.init(apiKey);
+  }
 
-  useEffect(() => {
-    // Check environment and API key
-    const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
+  if (!builder.apiKey) {
+    setError(
+      "Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.",
+    );
+    setLoading(false);
+    return;
+  }
 
-    setDebugInfo({
-      hasApiKey: !!apiKey,
-      apiKeyLength: apiKey?.length || 0,
-      nodeEnv: process.env.NODE_ENV,
-      builderInitialized: !!builder.apiKey,
-    });
+  // Just try the default "page" model first
+  builder
+    .getAll("page", {
+      limit: 50,
+      includeRefs: true,
+    })
+    .then((pages) => {
+      console.log("All Builder.io pages:", pages);
+      setAllPages(pages);
 
-    // Initialize Builder if not already done
-    if (!builder.apiKey && apiKey) {
-      builder.init(apiKey);
-    }
-
-    if (!builder.apiKey) {
-      setError(
-        "Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.",
+      // Look for "ObservationForm" content
+      const observationPage = pages.find(
+        (p) =>
+          p.name?.toLowerCase().includes("observationform") ||
+          p.name === "ObservationForm" ||
+          p.name?.toLowerCase().includes("observation"),
       );
+
+      if (observationPage) {
+        console.log("Found observation page:", observationPage);
+        setSelectedContent(observationPage);
+      }
       setLoading(false);
-      return;
-    }
-
-    // Fetch all Builder.io content from EngageX model
-    builder
-      .getAll("EngageX", {
-        limit: 50,
-        includeRefs: true,
-      })
-      .then((pages) => {
-        console.log("All Builder.io EngageX content:", pages);
-        setAllPages(pages);
-
-        // Look for "ObservationForm" content
-        const observationPage = pages.find(
-          (p) =>
-            p.name?.toLowerCase().includes("observationform") ||
-            p.name === "ObservationForm" ||
-            p.name?.toLowerCase().includes("observation"),
-        );
-
-        if (observationPage) {
-          console.log("Found observation page:", observationPage);
-          setSelectedContent(observationPage);
-        }
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Builder fetch error:", err);
-        setError(`Failed to fetch Builder.io content: ${err.message}`);
-        setLoading(false);
-      });
-  }, []);
-
-  const handleSelectPage = (page: any) => {
-    setSelectedContent(page);
-  };
-
-  // Loading state
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-white p-8">
-        <div className="max-w-4xl mx-auto">
-          <h1 className="text-2xl font-bold mb-4">
-            Loading Builder.io Content...
-          </h1>
-          <div className="animate-pulse">
-            <div className="h-4 bg-gray-200 rounded w-3/4 mb-2"></div>
-            <div className="h-4 bg-gray-200 rounded w-1/2"></div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Error state
-  if (error) {
-    return (
-      <div className="min-h-screen bg-white p-8">
-        <div className="max-w-4xl mx-auto">
-          <div className="bg-red-50 border border-red-200 rounded-lg p-6">
-            <h1 className="text-xl font-bold text-red-800 mb-2">
-              ❌ Builder.io Connection Error
-            </h1>
-            <p className="text-red-700 mb-4">{error}</p>
-
-            <div className="bg-white border rounded p-4">
-              <h3 className="font-semibold mb-2">Debug Information:</h3>
-              <pre className="text-sm text-gray-600 overflow-auto">
-                {JSON.stringify(debugInfo, null, 2)}
-              </pre>
-            </div>
-
-            <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded">
-              <h3 className="font-semibold text-blue-800 mb-2">
-                🔧 How to Fix:
-              </h3>
-              <ol className="list-decimal list-inside text-blue-700 space-y-1">
-                <li>Go to your Builder.io dashboard</li>
-                <li>Go to Account Settings → Organization Settings</li>
-                <li>Copy your Public API Key</li>
-                <li>
-                  Add it as an environment variable: NEXT_PUBLIC_BUILDER_API_KEY
-                </li>
-                <li>Restart your development server</li>
-              </ol>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Content found and selected
-  if (selectedContent) {
-    return (
-      <div className="min-h-screen bg-white">
-        {/* Status bar */}
-        <div className="bg-green-100 border-b border-green-200 p-4">
-          <div className="max-w-4xl mx-auto">
-            <p className="text-green-800">
-              ✅ <strong>Builder.io Content Loaded:</strong>{" "}
-              {selectedContent.name}
-            </p>
-            <button
-              onClick={() => setSelectedContent(null)}
-              className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
-            >
-              ← Back to Page List
-            </button>
-          </div>
-        </div>
-
-        {/* Render Builder.io content */}
-        <BuilderComponent
-          model="EngageX"
-          content={selectedContent}
-          options={{ includeRefs: true }}
-        />
-      </div>
-    );
-  }
-
-  // Page list view
-  return (
-    <div className="min-h-screen bg-white p-8">
-      <div className="max-w-4xl mx-auto">
-        <h1 className="text-3xl font-bold mb-6">
-          🔍 Builder.io Content Finder
-        </h1>
-
-        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
-          <h2 className="font-semibold text-yellow-800 mb-2">
-            Looking for "ObservationForm"
-          </h2>
-          <p className="text-yellow-700">
-            No content automatically matched. Please select your observation
-            form from the list below:
-          </p>
-        </div>
-
-        <div className="mb-6">
-          <h2 className="text-xl font-semibold mb-4">
-            Available Builder.io Content ({allPages.length})
-          </h2>
-
-          {allPages.length === 0 ? (
-            <div className="bg-gray-50 border rounded-lg p-6 text-center">
-              <p className="text-gray-600">
-                No content found in your Builder.io EngageX model.
-              </p>
-              <p className="text-gray-500 mt-2">
-                Make sure you have created and published content in Builder.io
-                under the EngageX model.
-              </p>
-            </div>
-          ) : (
-            <div className="grid gap-4">
-              {allPages.map((page, index) => (
-                <div
-                  key={page.id || index}
-                  className="border border-gray-200 rounded-lg p-4 hover:border-blue-300 transition-colors"
-                >
-                  <div className="flex justify-between items-start">
-                    <div className="flex-1">
-                      <h3 className="font-semibold text-lg text-gray-900">
-                        {page.name || "Untitled Page"}
-                      </h3>
-
-                      <div className="mt-2 space-y-1 text-sm text-gray-600">
-                        <div>
-                          <strong>ID:</strong> {page.id}
-                        </div>
-                        <div>
-                          <strong>URL:</strong> {page.data?.url || "No URL set"}
-                        </div>
-                        <div>
-                          <strong>Created:</strong>{" "}
-                          {page.createdDate
-                            ? new Date(page.createdDate).toLocaleDateString()
-                            : "Unknown"}
-                        </div>
-                        <div>
-                          <strong>Updated:</strong>{" "}
-                          {page.lastUpdated
-                            ? new Date(page.lastUpdated).toLocaleDateString()
-                            : "Unknown"}
-                        </div>
-                      </div>
-
-                      {/* Highlight potential matches */}
-                      {(page.name?.toLowerCase().includes("observationform") ||
-                        page.name?.toLowerCase().includes("observation")) && (
-                        <div className="mt-2 inline-block bg-orange-100 text-orange-800 px-2 py-1 rounded text-xs font-medium">
-                          🎯 Potential Match
-                        </div>
-                      )}
-                    </div>
-
-                    <button
-                      onClick={() => handleSelectPage(page)}
-                      className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-                    >
-                      Load This Page
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Debug info */}
-        <details className="mt-8">
-          <summary className="cursor-pointer font-semibold text-gray-700 hover:text-gray-900">
-            🔧 Debug Information (Click to expand)
-          </summary>
-          <div className="mt-4 p-4 bg-gray-50 border rounded">
-            <pre className="text-sm overflow-auto">
-              {JSON.stringify(
-                {
-                  ...debugInfo,
-                  totalPages: allPages.length,
-                  searchTerms: ["observationform", "observation"],
-                  model: "EngageX",
-                },
-                null,
-                2,
-              )}
-            </pre>
-          </div>
-        </details>
-      </div>
-    </div>
-  );
-}
+    })
+    .catch((err) => {
+      console.error("Builder fetch error:", err);
+      setError(`Failed to fetch Builder.io content: ${err.message}`);
+      setLoading(false);
+    });
+}, []);

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -3,11 +3,16 @@
 import { useEffect, useState } from "react";
 import { builder, BuilderComponent } from "@builder.io/react";
 
+type DebugState = {
+  successModel?: string;
+  allResults?: Record<string, any>;
+};
+
 export default function ObservationForm() {
-  const [content, setContent] = useState(null);
+  const [content, setContent] = useState<any>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
-  const [debug, setDebug] = useState({});
+  const [error, setError] = useState<string | null>(null);
+  const [debug, setDebug] = useState<DebugState>({});
 
   useEffect(() => {
     const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
@@ -27,7 +32,7 @@ export default function ObservationForm() {
         
         // Test all possible models
         const models = ["page", "content", "section", "symbol", "data"];
-        let results = {};
+        const results: Record<string, unknown> = {};
         
         for (const model of models) {
           try {
@@ -42,7 +47,7 @@ export default function ObservationForm() {
               setLoading(false);
               return;
             }
-          } catch (err) {
+          } catch (err: any) {
             results[model] = `Error: ${err.message}`;
             console.log(`${model}: ERROR -`, err.message);
           }
@@ -54,25 +59,47 @@ export default function ObservationForm() {
         setLoading(false);
         
       } catch (err) {
-        setError(err.message);
+        setError(
+          typeof err === "object" && err !== null && "message" in err
+            ? String((err as { message: unknown }).message)
+            : "An unknown error occurred"
+        );
         setLoading(false);
       }
     };
 
     fetchContent();
   }, []);
-
   if (loading) {
-    return (Testing All Builder.io Models...</hCheck console for detailed results);
-  }
+  return (
+    <h2>
+      Testing All Builder.io Models...
+      <br />
+      Check console for detailed results
+    </h2>
+  );
+}
 
   if (error) {
-    return (Debug Results{error}Model Test Results:{JSON.stringify(debug, null, 2)}Next Steps:Check console logs above for which models were testedGo to Builder.io → verify "ObservationForm" exists and is PUBLISHEDNote which section/tab your content is under in Builder.io</liVerify you're in the correct space (EngageX));
+    return (
+      <div style={{ color: "red" }}>
+        <h2>Error: {error}</h2>
+        <h3>Model Test Results:</h3>
+        <pre>{JSON.stringify(debug, null, 2)}</pre>
+        <h4>Next Steps:</h4>
+        <ol>
+          <li>Check console logs above for which models were tested</li>
+          <li>Go to Builder.io → verify &quot;ObservationForm&quot; exists and is PUBLISHED</li>
+          <li>Note which section/tab your content is under in Builder.io</li>
+          <li>Verify you&#39;re in the correct space (Engage_X)</li>
+        </ol>
+      </div>
+    );
   }
 
   if (content) {
-    return (✅SUCCESS!Found content: {content.name}Model: {debug.successModel});
+    return (<>✅SUCCESS! Found content: {content!.name} Model: {debug.successModel}</>);
   }
 
-  return (Unexpected state);
+  return <div>Unexpected state</div>;
 }

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -22,42 +22,70 @@ export default function ObservationForm() {
     builder.init(apiKey);
     
     setTimeout(async () => {
-      setDebugInfo({
+      const debugData = {
         hasApiKey: !!apiKey,
         apiKeyLength: apiKey?.length || 0,
+        apiKeyStart: apiKey?.substring(0, 8) + "...",
         nodeEnv: process.env.NODE_ENV,
         builderInitialized: !!builder.apiKey,
-      });
+      };
+
+      console.log("🔍 Debug info:", debugData);
 
       try {
-        const pages = await builder.getAll("page", {
-          limit: 50,
-          includeRefs: true,
-        });
+        // Try multiple models to find content
+        console.log("🚀 Testing multiple content models...");
+        
+        const models = ["page", "content", "section", "symbol"];
+        let allResults = {};
+        
+        for (const model of models) {
+          try {
+            console.log(`📄 Testing model: ${model}`);
+            const result = await builder.getAll(model, {
+              limit: 50,
+              includeRefs: true,
+              cachebust: true,
+            });
+            allResults[model] = result ? result.length : 0;
+            console.log(`📊 Model "${model}" returned ${result ? result.length : 0} items`);
+            
+            if (result && result.length > 0) {
+              setAllPages(result);
+              console.log(`✅ Found content in "${model}" model:`, result);
+              
+              // Look for ObservationForm
+              const observationPage = result.find(
+                (p) =>
+                  p.name?.toLowerCase().includes("observationform") ||
+                  p.name === "ObservationForm" ||
+                  p.name?.toLowerCase().includes("observation")
+              );
 
-        console.log("Builder.io pages:", pages);
-        setAllPages(pages || []);
-
-        if (!pages || pages.length === 0) {
-          setError("No content found in Builder.io. Please check your API key and published content.");
-          setLoading(false);
-          return;
+              if (observationPage) {
+                console.log("🎯 Found ObservationForm:", observationPage);
+                setSelectedContent(observationPage);
+              }
+              
+              setDebugInfo({...debugData, successfulModel: model, modelResults: allResults});
+              setLoading(false);
+              return;
+            }
+          } catch (modelErr) {
+            console.error(`❌ Error with model ${model}:`, modelErr);
+            allResults[model] = `Error: ${modelErr.message}`;
+          }
         }
 
-        const observationPage = pages.find(
-          (p) =>
-            p.name?.toLowerCase().includes("observationform") ||
-            p.name === "ObservationForm" ||
-            p.name?.toLowerCase().includes("observation")
-        );
-
-        if (observationPage) {
-          setSelectedContent(observationPage);
-        }
-
+        // If no content found in any model
+        setError(`No content found in any Builder.io model. Checked: ${models.join(", ")}`);
+        setDebugInfo({...debugData, modelResults: allResults, totalModelsChecked: models.length});
         setLoading(false);
+
       } catch (err) {
+        console.error("💥 General error:", err);
         setError(`Failed to fetch Builder.io content: ${err.message || err}`);
+        setDebugInfo({...debugData, generalError: err.message});
         setLoading(false);
       }
     }, 100);
@@ -68,22 +96,22 @@ export default function ObservationForm() {
   };
 
   if (loading) {
-    return (Loading Builder.io Content...</h</div
+    return (🔍 Scanning Builder.io Models...Testing: page, content, section, symbol models...);
   }
 
   if (error) {
-    return (❌ Builder.io Error</h1{error}Debug Information:{JSON.stringify(debugInfo, null, 2)});
+    return (🔍 Builder.io Scan Results{error}📊 Model Scan Results:{JSON.stringify(debugInfo, null, 2)}</pre🔧 Next Steps:Check Builder.io Dashboard:Go to builder.io and verify your "ObservationForm" content exists and is publishedVerify Space:Make sure you're in the correct "EngageX" spaceCheck Content Model:Note which tab/section your content is under in Builder.ioAPI Key Permissions:Ensure your API key has read access to published content);
   }
 
   if (selectedContent) {
-    return (✅Builder.io Content Loaded:{selectedContent.name}setSelectedContent(null)}
+    return (✅Builder.io Content Loaded:{selectedContent.name}Found in model:{debugInfo.successfulModel}setSelectedContent(null)}
               className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
             >
-              ← Back to Page List</button);
+              ← Back to Content List);
   }
 
-  return (🔍 Builder.io Content FinderAvailable Builder.io Pages ({allPages.length}){allPages.map((page, index) => ({page.name || "Untitled Page"}ID:{page.id}URL:{page.data?.url || "No URL set"}{(page.name?.toLowerCase().includes("observationform") || page.name?.toLowerCase().includes("observation")) && (🎯 Potential Match)}handleSelectPage(page)}
-                    className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+  return (🎯 Found Builder.io Content!✅ Success!Found {allPages.length} items in the{debugInfo.successfulModel}modelClick "Load This Content" on your ObservationFormAvailable Content ({allPages.length}){allPages.map((page, index) => ({page.name || "Untitled Page"}ID:{page.id}Model:{debugInfo.successfulModel}URL:{page.data?.url || "No URL set"}{(page.name?.toLowerCase().includes("observationform") || page.name?.toLowerCase().includes("observation")) && (🎯 OBSERVATION FORM DETECTED!)}handleSelectPage(page)}
+                    className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors font-semibold"
                   >
-                    Load This Page))}</div);
+                    Load This Content))}🔧 Technical Details (Click to expand)</summary{JSON.stringify({...debugInfo, totalPages: allPages.length}, null, 2)}</preails
 }

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -5,56 +5,104 @@ import { builder, BuilderComponent } from "@builder.io/react";
 
 export default function ObservationForm() {
   const [content, setContent] = useState(null);
+  const [allPages, setAllPages] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+  const [debug, setDebug] = useState({});
 
   useEffect(() => {
     const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
+    
+    console.log("Starting Builder.io fetch...");
+    console.log("API Key exists:", !!apiKey);
+    console.log("API Key length:", apiKey?.length);
 
     if (!apiKey) {
-      setError("Builder API key not found");
+      setError("❌ No API key found");
       setLoading(false);
       return;
     }
 
-    builder.init(apiKey);
-    
-    builder.getAll("page")
-      .then((pages) => {
-        console.log("Pages found:", pages);
-        
-        if (pages && pages.length > 0) {
-          const observationForm = pages.find(p => 
-            p.name && p.name.toLowerCase().includes("observation")
-          );
+    try {
+      builder.init(apiKey);
+      console.log("Builder initialized");
+
+      // Add timeout to prevent hanging
+      const fetchWithTimeout = Promise.race([
+        builder.getAll("page", { limit: 10 }),
+        new Promise((_, reject) => 
+          setTimeout(() => reject(new Error("Request timeout after 10 seconds")), 10000)
+        )
+      ]);
+
+      fetchWithTimeout
+        .then((pages) => {
+          console.log("✅ Success! Pages received:", pages);
+          setAllPages(pages || []);
           
-          if (observationForm) {
-            setContent(observationForm);
+          if (pages && pages.length > 0) {
+            // Look for observation form
+            const obsForm = pages.find(p => 
+              p.name && (
+                p.name.toLowerCase().includes("observation") ||
+                p.name === "ObservationForm"
+              )
+            );
+            
+            if (obsForm) {
+              console.log("🎯 Found ObservationForm:", obsForm.name);
+              setContent(obsForm);
+            } else {
+              console.log("📝 Using first available page:", pages[0].name);
+              setContent(pages[0]);
+            }
+            
+            setDebug({
+              totalPages: pages.length,
+              pageNames: pages.map(p => p.name),
+              foundObservation: !!obsForm
+            });
           } else {
-            setContent(pages[0]);
+            setError("⚠️ No pages found in Builder.io");
           }
-        } else {
-          setError("No content found in Builder.io");
-        }
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Builder error:", err);
-        setError("Failed to load content: " + err.message);
-        setLoading(false);
-      });
+          setLoading(false);
+        })
+        .catch((err) => {
+          console.error("❌ Builder.io error:", err);
+          setError(`API Error: ${err.message}`);
+          setDebug({ errorDetails: err.toString() });
+          setLoading(false);
+        });
+
+    } catch (initError) {
+      console.error("❌ Initialization error:", initError);
+      setError(`Init Error: ${initError.message}`);
+      setLoading(false);
+    }
   }, []);
 
+  const selectPage = (page) => {
+    setContent(page);
+  };
+
   if (loading) {
-    return (Loading...Loading Builder.io content...);
+    return (Loading Builder.io...This should take less than 10 seconds);
   }
 
   if (error) {
-    return (Error{error}</piv
+    return (Builder.io Error{error}Debug Info{JSON.stringify(debug, null, 2)}Quick Fixes:Check your .env.local file has NEXT_PUBLIC_BUILDER_API_KEYVerify the API key is from your EngageX space in Builder.ioMake sure your ObservationForm content is published);
   }
 
   if (content) {
-    return (Content loaded:{content.name});
+    return (✅Builder.io Content:{content.name}Found {allPages.length} total pagessetContent(null)}
+              className="px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
+            >
+              Browse All Pages);
   }
 
-  return (No ContentNo Builder.io content found</piv
+  // Page selector view
+  return (🎯 Builder.io Content Found!Found{allPages.length}pages. Select your ObservationForm:{allPages.map((page, index) => ({page.name || "Untitled"}ID: {page.id}{page.name?.toLowerCase().includes("observation") && (🎯 OBSERVATION FORM)}selectPage(page)}
+                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+                >
+                  Load This Page))});
+}

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -5,104 +5,74 @@ import { builder, BuilderComponent } from "@builder.io/react";
 
 export default function ObservationForm() {
   const [content, setContent] = useState(null);
-  const [allPages, setAllPages] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [debug, setDebug] = useState({});
 
   useEffect(() => {
     const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
-    
-    console.log("Starting Builder.io fetch...");
-    console.log("API Key exists:", !!apiKey);
-    console.log("API Key length:", apiKey?.length);
 
     if (!apiKey) {
-      setError("❌ No API key found");
+      setError("No API key");
       setLoading(false);
       return;
     }
 
-    try {
-      builder.init(apiKey);
-      console.log("Builder initialized");
+    builder.init(apiKey);
 
-      // Add timeout to prevent hanging
-      const fetchWithTimeout = Promise.race([
-        builder.getAll("page", { limit: 10 }),
-        new Promise((_, reject) => 
-          setTimeout(() => reject(new Error("Request timeout after 10 seconds")), 10000)
-        )
-      ]);
-
-      fetchWithTimeout
-        .then((pages) => {
-          console.log("✅ Success! Pages received:", pages);
-          setAllPages(pages || []);
-          
-          if (pages && pages.length > 0) {
-            // Look for observation form
-            const obsForm = pages.find(p => 
-              p.name && (
-                p.name.toLowerCase().includes("observation") ||
-                p.name === "ObservationForm"
-              )
-            );
+    // Try EVERY possible way to get content
+    const fetchContent = async () => {
+      try {
+        console.log("=== TESTING ALL MODELS ===");
+        
+        // Test all possible models
+        const models = ["page", "content", "section", "symbol", "data"];
+        let results = {};
+        
+        for (const model of models) {
+          try {
+            const data = await builder.getAll(model, { limit: 10 });
+            results[model] = data?.length || 0;
+            console.log(`${model}: ${data?.length || 0} items`);
             
-            if (obsForm) {
-              console.log("🎯 Found ObservationForm:", obsForm.name);
-              setContent(obsForm);
-            } else {
-              console.log("📝 Using first available page:", pages[0].name);
-              setContent(pages[0]);
+            if (data && data.length > 0) {
+              console.log(`✅ FOUND CONTENT IN ${model}:`, data);
+              setContent(data[0]); // Use first item
+              setDebug({ successModel: model, allResults: results });
+              setLoading(false);
+              return;
             }
-            
-            setDebug({
-              totalPages: pages.length,
-              pageNames: pages.map(p => p.name),
-              foundObservation: !!obsForm
-            });
-          } else {
-            setError("⚠️ No pages found in Builder.io");
+          } catch (err) {
+            results[model] = `Error: ${err.message}`;
+            console.log(`${model}: ERROR -`, err.message);
           }
-          setLoading(false);
-        })
-        .catch((err) => {
-          console.error("❌ Builder.io error:", err);
-          setError(`API Error: ${err.message}`);
-          setDebug({ errorDetails: err.toString() });
-          setLoading(false);
-        });
+        }
+        
+        // If nothing found, show debug info
+        setError("No content found in any model");
+        setDebug({ allResults: results });
+        setLoading(false);
+        
+      } catch (err) {
+        setError(err.message);
+        setLoading(false);
+      }
+    };
 
-    } catch (initError) {
-      console.error("❌ Initialization error:", initError);
-      setError(`Init Error: ${initError.message}`);
-      setLoading(false);
-    }
+    fetchContent();
   }, []);
 
-  const selectPage = (page) => {
-    setContent(page);
-  };
-
   if (loading) {
-    return (Loading Builder.io...This should take less than 10 seconds);
+    return (Testing All Builder.io Models...</hCheck console for detailed results);
   }
 
   if (error) {
-    return (Builder.io Error{error}Debug Info{JSON.stringify(debug, null, 2)}Quick Fixes:Check your .env.local file has NEXT_PUBLIC_BUILDER_API_KEYVerify the API key is from your EngageX space in Builder.ioMake sure your ObservationForm content is published);
+    return (Debug Results{error}Model Test Results:{JSON.stringify(debug, null, 2)}Next Steps:Check console logs above for which models were testedGo to Builder.io → verify "ObservationForm" exists and is PUBLISHEDNote which section/tab your content is under in Builder.io</liVerify you're in the correct space (EngageX));
   }
 
   if (content) {
-    return (✅Builder.io Content:{content.name}Found {allPages.length} total pagessetContent(null)}
-              className="px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
-            >
-              Browse All Pages);
+    return (✅SUCCESS!Found content: {content.name}Model: {debug.successModel});
   }
 
-  // Page selector view
-  return (🎯 Builder.io Content Found!Found{allPages.length}pages. Select your ObservationForm:{allPages.map((page, index) => ({page.name || "Untitled"}ID: {page.id}{page.name?.toLowerCase().includes("observation") && (🎯 OBSERVATION FORM)}selectPage(page)}
-                  className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
-                >
-                  Load This Page))});
+  return (Unexpected state);
 }

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -72,11 +72,10 @@ export default function ObservationForm() {
   }, []);
   if (loading) {
   return (
-    <h2>
-      Testing All Builder.io Models...
-      <br />
+    <div>
+      Testing All Builder.io Models...<br />
       Check console for detailed results
-    </h2>
+    </div>
   );
 }
 

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -146,7 +146,7 @@ export default function ObservationForm() {
 
         {/* Render Builder.io content */}
         <BuilderComponent
-          model="page"
+          model="EngageX"
           content={selectedContent}
           options={{ includeRefs: true }}
         />
@@ -164,7 +164,7 @@ export default function ObservationForm() {
 
         <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
           <h2 className="font-semibold text-yellow-800 mb-2">
-            Looking for "Mark's observation 2"
+            Looking for "ObservationForm"
           </h2>
           <p className="text-yellow-700">
             No content automatically matched. Please select your observation
@@ -174,16 +174,17 @@ export default function ObservationForm() {
 
         <div className="mb-6">
           <h2 className="text-xl font-semibold mb-4">
-            Available Builder.io Pages ({allPages.length})
+            Available Builder.io Content ({allPages.length})
           </h2>
 
           {allPages.length === 0 ? (
             <div className="bg-gray-50 border rounded-lg p-6 text-center">
               <p className="text-gray-600">
-                No pages found in your Builder.io space.
+                No content found in your Builder.io EngageX model.
               </p>
               <p className="text-gray-500 mt-2">
-                Make sure you have created and published content in Builder.io.
+                Make sure you have created and published content in Builder.io
+                under the EngageX model.
               </p>
             </div>
           ) : (
@@ -221,7 +222,7 @@ export default function ObservationForm() {
                       </div>
 
                       {/* Highlight potential matches */}
-                      {(page.name?.toLowerCase().includes("mark") ||
+                      {(page.name?.toLowerCase().includes("observationform") ||
                         page.name?.toLowerCase().includes("observation")) && (
                         <div className="mt-2 inline-block bg-orange-100 text-orange-800 px-2 py-1 rounded text-xs font-medium">
                           🎯 Potential Match
@@ -253,7 +254,8 @@ export default function ObservationForm() {
                 {
                   ...debugInfo,
                   totalPages: allPages.length,
-                  searchTerms: ["mark", "observation", "/observation-form"],
+                  searchTerms: ["observationform", "observation"],
+                  model: "EngageX",
                 },
                 null,
                 2,

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -30,31 +30,29 @@ export default function ObservationForm() {
         builderInitialized: !!builder.apiKey,
       };
 
-      console.log("🔍 Debug info:", debugData);
+      console.log("Debug info:", debugData);
 
       try {
-        // Try multiple models to find content
-        console.log("🚀 Testing multiple content models...");
+        console.log("Testing multiple content models...");
         
         const models = ["page", "content", "section", "symbol"];
         let allResults = {};
         
         for (const model of models) {
           try {
-            console.log(`📄 Testing model: ${model}`);
+            console.log(`Testing model: ${model}`);
             const result = await builder.getAll(model, {
               limit: 50,
               includeRefs: true,
               cachebust: true,
             });
             allResults[model] = result ? result.length : 0;
-            console.log(`📊 Model "${model}" returned ${result ? result.length : 0} items`);
+            console.log(`Model "${model}" returned ${result ? result.length : 0} items`);
             
             if (result && result.length > 0) {
               setAllPages(result);
-              console.log(`✅ Found content in "${model}" model:`, result);
+              console.log(`Found content in "${model}" model:`, result);
               
-              // Look for ObservationForm
               const observationPage = result.find(
                 (p) =>
                   p.name?.toLowerCase().includes("observationform") ||
@@ -63,7 +61,7 @@ export default function ObservationForm() {
               );
 
               if (observationPage) {
-                console.log("🎯 Found ObservationForm:", observationPage);
+                console.log("Found ObservationForm:", observationPage);
                 setSelectedContent(observationPage);
               }
               
@@ -72,18 +70,17 @@ export default function ObservationForm() {
               return;
             }
           } catch (modelErr) {
-            console.error(`❌ Error with model ${model}:`, modelErr);
+            console.error(`Error with model ${model}:`, modelErr);
             allResults[model] = `Error: ${modelErr.message}`;
           }
         }
 
-        // If no content found in any model
         setError(`No content found in any Builder.io model. Checked: ${models.join(", ")}`);
         setDebugInfo({...debugData, modelResults: allResults, totalModelsChecked: models.length});
         setLoading(false);
 
       } catch (err) {
-        console.error("💥 General error:", err);
+        console.error("General error:", err);
         setError(`Failed to fetch Builder.io content: ${err.message || err}`);
         setDebugInfo({...debugData, generalError: err.message});
         setLoading(false);
@@ -96,22 +93,22 @@ export default function ObservationForm() {
   };
 
   if (loading) {
-    return (🔍 Scanning Builder.io Models...Testing: page, content, section, symbol models...);
+    return (Loading Builder.io Content...Testing: page, content, section, symbol models...</p);
   }
 
   if (error) {
-    return (🔍 Builder.io Scan Results{error}📊 Model Scan Results:{JSON.stringify(debugInfo, null, 2)}</pre🔧 Next Steps:Check Builder.io Dashboard:Go to builder.io and verify your "ObservationForm" content exists and is publishedVerify Space:Make sure you're in the correct "EngageX" spaceCheck Content Model:Note which tab/section your content is under in Builder.ioAPI Key Permissions:Ensure your API key has read access to published content);
+    return (Builder.io Scan Results{error}Model Scan Results:{JSON.stringify(debugInfo, null, 2)}Next Steps:Check Builder.io Dashboard:Go to builder.io and verify your "ObservationForm" content exists and is publishedVerify Space:Make sure you're in the correct "EngageX" spaceCheck Content Model:Note which tab/section your content is under in Builder.ioAPI Key Permissions:Ensure your API key has read access to published content);
   }
 
   if (selectedContent) {
-    return (✅Builder.io Content Loaded:{selectedContent.name}Found in model:{debugInfo.successfulModel}setSelectedContent(null)}
+    return (Builder.io Content Loaded:{selectedContent.name}Found in model:{debugInfo.successfulModel}setSelectedContent(null)}
               className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
             >
-              ← Back to Content List);
+              Back to Content List</button);
   }
 
-  return (🎯 Found Builder.io Content!✅ Success!Found {allPages.length} items in the{debugInfo.successfulModel}modelClick "Load This Content" on your ObservationFormAvailable Content ({allPages.length}){allPages.map((page, index) => ({page.name || "Untitled Page"}ID:{page.id}Model:{debugInfo.successfulModel}URL:{page.data?.url || "No URL set"}{(page.name?.toLowerCase().includes("observationform") || page.name?.toLowerCase().includes("observation")) && (🎯 OBSERVATION FORM DETECTED!)}handleSelectPage(page)}
+  return (Found Builder.io Content!Success!Found {allPages.length} items in the{debugInfo.successfulModel}</strongClick "Load This Content" on your ObservationFormAvailable Content ({allPages.length}){allPages.map((page, index) => ({page.name || "Untitled Page"}ID:{page.id}Model:{debugInfo.successfulModel}URL:{page.data?.url || "No URL set"}{(page.name?.toLowerCase().includes("observationform") || page.name?.toLowerCase().includes("observation")) && (OBSERVATION FORM DETECTED!</div</divhandleSelectPage(page)}
                     className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors font-semibold"
                   >
-                    Load This Content))}🔧 Technical Details (Click to expand)</summary{JSON.stringify({...debugInfo, totalPages: allPages.length}, null, 2)}</preails
+                    Load This Content))}Technical Details (Click to expand){JSON.stringify({...debugInfo, totalPages: allPages.length}, null, 2)}</preails
 }

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -34,22 +34,22 @@ export default function ObservationForm() {
       return;
     }
 
-    // Fetch all Builder.io pages
+    // Fetch all Builder.io content from EngageX model
     builder
-      .getAll("page", {
+      .getAll("EngageX", {
         limit: 50,
         includeRefs: true,
       })
       .then((pages) => {
-        console.log("All Builder.io pages:", pages);
+        console.log("All Builder.io EngageX content:", pages);
         setAllPages(pages);
 
-        // Look for "Mark's observation 2" or any observation-related content
+        // Look for "ObservationForm" content
         const observationPage = pages.find(
           (p) =>
-            p.name?.toLowerCase().includes("mark") ||
-            p.name?.toLowerCase().includes("observation") ||
-            p.data?.url === "/observation-form",
+            p.name?.toLowerCase().includes("observationform") ||
+            p.name === "ObservationForm" ||
+            p.name?.toLowerCase().includes("observation"),
         );
 
         if (observationPage) {

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1,54 +1,208 @@
-useEffect(() => {
-  // Check environment and API key
-  const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
+"use client";
 
-  setDebugInfo({
-    hasApiKey: !!apiKey,
-    apiKeyLength: apiKey?.length || 0,
-    nodeEnv: process.env.NODE_ENV,
-    builderInitialized: !!builder.apiKey,
-  });
+import { useEffect, useState } from "react";
+import { builder, BuilderComponent } from "@builder.io/react";
 
-  // Initialize Builder if not already done
-  if (!builder.apiKey && apiKey) {
-    builder.init(apiKey);
-  }
+export default function ObservationForm() {
+  const [allPages, setAllPages] = useState<any[]>([]);
+  const [selectedContent, setSelectedContent] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [debugInfo, setDebugInfo] = useState({});
 
-  if (!builder.apiKey) {
-    setError(
-      "Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.",
-    );
-    setLoading(false);
-    return;
-  }
+  useEffect(() => {
+    // Check environment and API key
+    const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
 
-  // Just try the default "page" model first
-  builder
-    .getAll("page", {
-      limit: 50,
-      includeRefs: true,
-    })
-    .then((pages) => {
-      console.log("All Builder.io pages:", pages);
-      setAllPages(pages);
-
-      // Look for "ObservationForm" content
-      const observationPage = pages.find(
-        (p) =>
-          p.name?.toLowerCase().includes("observationform") ||
-          p.name === "ObservationForm" ||
-          p.name?.toLowerCase().includes("observation"),
-      );
-
-      if (observationPage) {
-        console.log("Found observation page:", observationPage);
-        setSelectedContent(observationPage);
-      }
-      setLoading(false);
-    })
-    .catch((err) => {
-      console.error("Builder fetch error:", err);
-      setError(`Failed to fetch Builder.io content: ${err.message}`);
-      setLoading(false);
+    setDebugInfo({
+      hasApiKey: !!apiKey,
+      apiKeyLength: apiKey?.length || 0,
+      nodeEnv: process.env.NODE_ENV,
+      builderInitialized: !!builder.apiKey,
     });
-}, []);
+
+    // Initialize Builder if not already done
+    if (!builder.apiKey && apiKey) {
+      builder.init(apiKey);
+    }
+
+    if (!builder.apiKey) {
+      setError(
+        "Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.",
+      );
+      setLoading(false);
+      return;
+    }
+
+    // First try to get content directly by URL path
+    builder
+      .get("page", {
+        userAttributes: { urlPath: "/observation-form" },
+        includeRefs: true,
+      })
+      .then((content) => {
+        if (content) {
+          console.log("Found observation form content by URL:", content);
+          setSelectedContent(content);
+          setAllPages([content]);
+          setLoading(false);
+          return; // Exit early if we found it
+        }
+        
+        // If no content found by URL, try getAll as fallback
+        return builder.getAll("page", {
+          limit: 50,
+          includeRefs: true,
+        });
+      })
+      .then((pages) => {
+        // Only process this if we didn't already find content above
+        if (selectedContent) return;
+        
+        if (pages && Array.isArray(pages)) {
+          console.log("All Builder.io pages:", pages);
+          setAllPages(pages);
+
+          // Look for "ObservationForm" content
+          const observationPage = pages.find(
+            (p) =>
+              p.name?.toLowerCase().includes("observationform") ||
+              p.name === "ObservationForm" ||
+              p.name?.toLowerCase().includes("observation") ||
+              p.data?.url === "/observation-form"
+          );
+
+          if (observationPage) {
+            console.log("Found observation page:", observationPage);
+            setSelectedContent(observationPage);
+          }
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error("Builder fetch error:", err);
+        setError(`Failed to fetch Builder.io content: ${err.message}`);
+        setLoading(false);
+      });
+  }, []);
+
+  const handleSelectPage = (page: any) => {
+    setSelectedContent(page);
+  };
+
+  // Loading state
+  if (loading) {
+    return <div>Loading Builder.io Content...</div>;
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div>
+        <h2 style={{ color: "red" }}>Builder.io Connection Error</h2>
+        <p>{error}</p>
+        <h3>Debug Information:</h3>
+        <pre>{JSON.stringify(debugInfo, null, 2)}</pre>
+      </div>
+    );
+  }
+
+  // Content found and selected
+  if (selectedContent) {
+    return (
+      <div>
+        {/* Status bar */}
+        <div className="mb-4 flex items-center gap-2">
+          <span role="img" aria-label="success">✅</span>
+          Builder.io Content Loaded: <strong>{selectedContent.name}</strong>
+        </div>
+        <button
+          onClick={() => setSelectedContent(null)}
+          className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
+        >
+          ← Back to Page List
+        </button>
+        {/* Render Builder.io content */}
+        <div className="mt-6 border rounded p-4 bg-white shadow">
+          <BuilderComponent model="page" content={selectedContent} />
+        </div>
+      </div>
+    );
+  }
+
+  // Page list view
+  return (
+    <div>
+      <h1>Builder.io Content Finder</h1>
+      <h2>Looking for &quot;ObservationForm&quot;</h2>
+      <p>
+        No content automatically matched. Please select your observation form from the list below:
+      </p>
+      <h2>
+        Available Builder.io Pages ({allPages.length})
+      </h2>
+      {allPages.length === 0 ? (
+        <div>
+          <p>No pages found in your Builder.io space.</p>
+          <p>Make sure you have created and published content in Builder.io.</p>
+        </div>
+      ) : (
+        <div>
+          {allPages.map((page: any, index: number) => (
+            <div key={page.id || index} className="mb-4 p-4 border rounded bg-gray-50">
+              <div>
+                <strong>{page.name || "Untitled Page"}</strong>
+              </div>
+              <div>ID: {page.id}</div>
+              <div>URL: {page.data?.url || "No URL set"}</div>
+              <div>
+                Created:{" "}
+                <strong>
+                  {page.createdDate
+                    ? new Date(page.createdDate).toLocaleDateString()
+                    : "Unknown"}
+                </strong>
+              </div>
+              <div>
+                Updated:{" "}
+                <strong>
+                  {page.lastUpdated
+                    ? new Date(page.lastUpdated).toLocaleDateString()
+                    : "Unknown"}
+                </strong>
+              </div>
+              {/* Highlight potential matches */}
+              {(page.name?.toLowerCase().includes("observationform") ||
+                page.name?.toLowerCase().includes("observation")) && (
+                <div className="text-green-700 font-semibold mt-2">
+                  🎯 Potential Match
+                </div>
+              )}
+              <button
+                onClick={() => handleSelectPage(page)}
+                className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+              >
+                Load This Page
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+      {/* Debug info */}
+      <details className="mt-6">
+        <summary>🔧 Debug Information (Click to expand)</summary>
+        <pre>
+          {JSON.stringify(
+            {
+              ...debugInfo,
+              totalPages: allPages.length,
+              searchTerms: ["observationform", "observation", "/observation-form"],
+            },
+            null,
+            2,
+          )}
+        </pre>
+      </details>
+    </div>
+  );
+}

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -4,111 +4,57 @@ import { useEffect, useState } from "react";
 import { builder, BuilderComponent } from "@builder.io/react";
 
 export default function ObservationForm() {
-  const [allPages, setAllPages] = useState([]);
-  const [selectedContent, setSelectedContent] = useState(null);
+  const [content, setContent] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [debugInfo, setDebugInfo] = useState({});
 
   useEffect(() => {
     const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
 
     if (!apiKey) {
-      setError("Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.");
+      setError("Builder API key not found");
       setLoading(false);
       return;
     }
 
     builder.init(apiKey);
     
-    setTimeout(async () => {
-      const debugData = {
-        hasApiKey: !!apiKey,
-        apiKeyLength: apiKey?.length || 0,
-        apiKeyStart: apiKey?.substring(0, 8) + "...",
-        nodeEnv: process.env.NODE_ENV,
-        builderInitialized: !!builder.apiKey,
-      };
-
-      console.log("Debug info:", debugData);
-
-      try {
-        console.log("Testing multiple content models...");
+    builder.getAll("page")
+      .then((pages) => {
+        console.log("Pages found:", pages);
         
-        const models = ["page", "content", "section", "symbol"];
-        let allResults = {};
-        
-        for (const model of models) {
-          try {
-            console.log(`Testing model: ${model}`);
-            const result = await builder.getAll(model, {
-              limit: 50,
-              includeRefs: true,
-              cachebust: true,
-            });
-            allResults[model] = result ? result.length : 0;
-            console.log(`Model "${model}" returned ${result ? result.length : 0} items`);
-            
-            if (result && result.length > 0) {
-              setAllPages(result);
-              console.log(`Found content in "${model}" model:`, result);
-              
-              const observationPage = result.find(
-                (p) =>
-                  p.name?.toLowerCase().includes("observationform") ||
-                  p.name === "ObservationForm" ||
-                  p.name?.toLowerCase().includes("observation")
-              );
-
-              if (observationPage) {
-                console.log("Found ObservationForm:", observationPage);
-                setSelectedContent(observationPage);
-              }
-              
-              setDebugInfo({...debugData, successfulModel: model, modelResults: allResults});
-              setLoading(false);
-              return;
-            }
-          } catch (modelErr) {
-            console.error(`Error with model ${model}:`, modelErr);
-            allResults[model] = `Error: ${modelErr.message}`;
+        if (pages && pages.length > 0) {
+          const observationForm = pages.find(p => 
+            p.name && p.name.toLowerCase().includes("observation")
+          );
+          
+          if (observationForm) {
+            setContent(observationForm);
+          } else {
+            setContent(pages[0]);
           }
+        } else {
+          setError("No content found in Builder.io");
         }
-
-        setError(`No content found in any Builder.io model. Checked: ${models.join(", ")}`);
-        setDebugInfo({...debugData, modelResults: allResults, totalModelsChecked: models.length});
         setLoading(false);
-
-      } catch (err) {
-        console.error("General error:", err);
-        setError(`Failed to fetch Builder.io content: ${err.message || err}`);
-        setDebugInfo({...debugData, generalError: err.message});
+      })
+      .catch((err) => {
+        console.error("Builder error:", err);
+        setError("Failed to load content: " + err.message);
         setLoading(false);
-      }
-    }, 100);
+      });
   }, []);
 
-  const handleSelectPage = (page: any) => {
-    setSelectedContent(page);
-  };
-
   if (loading) {
-    return (Loading Builder.io Content...Testing: page, content, section, symbol models...</p);
+    return (Loading...Loading Builder.io content...);
   }
 
   if (error) {
-    return (Builder.io Scan Results{error}Model Scan Results:{JSON.stringify(debugInfo, null, 2)}Next Steps:Check Builder.io Dashboard:Go to builder.io and verify your "ObservationForm" content exists and is publishedVerify Space:Make sure you're in the correct "EngageX" spaceCheck Content Model:Note which tab/section your content is under in Builder.ioAPI Key Permissions:Ensure your API key has read access to published content);
+    return (Error{error}</piv
   }
 
-  if (selectedContent) {
-    return (Builder.io Content Loaded:{selectedContent.name}Found in model:{debugInfo.successfulModel}setSelectedContent(null)}
-              className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
-            >
-              Back to Content List</button);
+  if (content) {
+    return (Content loaded:{content.name});
   }
 
-  return (Found Builder.io Content!Success!Found {allPages.length} items in the{debugInfo.successfulModel}</strongClick "Load This Content" on your ObservationFormAvailable Content ({allPages.length}){allPages.map((page, index) => ({page.name || "Untitled Page"}ID:{page.id}Model:{debugInfo.successfulModel}URL:{page.data?.url || "No URL set"}{(page.name?.toLowerCase().includes("observationform") || page.name?.toLowerCase().includes("observation")) && (OBSERVATION FORM DETECTED!</div</divhandleSelectPage(page)}
-                    className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors font-semibold"
-                  >
-                    Load This Content))}Technical Details (Click to expand){JSON.stringify({...debugInfo, totalPages: allPages.length}, null, 2)}</preails
-}
+  return (No ContentNo Builder.io content found</piv

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -29,17 +29,17 @@ export default function ObservationForm() {
     const fetchContent = async () => {
       try {
         console.log("=== TESTING ALL MODELS ===");
-        
+
         // Test all possible models
         const models = ["page", "content", "section", "symbol", "data"];
         const results: Record<string, unknown> = {};
-        
+
         for (const model of models) {
           try {
             const data = await builder.getAll(model, { limit: 10 });
             results[model] = data?.length || 0;
             console.log(`${model}: ${data?.length || 0} items`);
-            
+
             if (data && data.length > 0) {
               console.log(`✅ FOUND CONTENT IN ${model}:`, data);
               setContent(data[0]); // Use first item
@@ -52,12 +52,11 @@ export default function ObservationForm() {
             console.log(`${model}: ERROR -`, err.message);
           }
         }
-        
+
         // If nothing found, show debug info
         setError("No content found in any model");
         setDebug({ allResults: results });
         setLoading(false);
-        
       } catch (err) {
         setError(
           typeof err === "object" && err !== null && "message" in err
@@ -70,14 +69,15 @@ export default function ObservationForm() {
 
     fetchContent();
   }, []);
+
   if (loading) {
-  return (
-    <div>
-      Testing All Builder.io Models...<br />
-      Check console for detailed results
-    </div>
-  );
-}
+    return (
+      <div>
+        Testing All Builder.io Models...<br />
+        Check console for detailed results
+      </div>
+    );
+  }
 
   if (error) {
     return (
@@ -97,7 +97,11 @@ export default function ObservationForm() {
   }
 
   if (content) {
-    return (<>✅SUCCESS! Found content: {content!.name} Model: {debug.successModel}</>);
+    return (
+      <>
+        ✅SUCCESS! Found content: {content!.name} Model: {debug.successModel}
+      </>
+    );
   }
 
   return <div>Unexpected state</div>;

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -4,205 +4,86 @@ import { useEffect, useState } from "react";
 import { builder, BuilderComponent } from "@builder.io/react";
 
 export default function ObservationForm() {
-  const [allPages, setAllPages] = useState<any[]>([]);
-  const [selectedContent, setSelectedContent] = useState<any>(null);
+  const [allPages, setAllPages] = useState([]);
+  const [selectedContent, setSelectedContent] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState(null);
   const [debugInfo, setDebugInfo] = useState({});
 
   useEffect(() => {
-    // Check environment and API key
     const apiKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
 
-    setDebugInfo({
-      hasApiKey: !!apiKey,
-      apiKeyLength: apiKey?.length || 0,
-      nodeEnv: process.env.NODE_ENV,
-      builderInitialized: !!builder.apiKey,
-    });
-
-    // Initialize Builder if not already done
-    if (!builder.apiKey && apiKey) {
-      builder.init(apiKey);
-    }
-
-    if (!builder.apiKey) {
-      setError(
-        "Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.",
-      );
+    if (!apiKey) {
+      setError("Builder API key not found. Please set NEXT_PUBLIC_BUILDER_API_KEY environment variable.");
       setLoading(false);
       return;
     }
 
-    // First try to get content directly by URL path
-    builder
-      .get("page", {
-        userAttributes: { urlPath: "/observation-form" },
-        includeRefs: true,
-      })
-      .then((content) => {
-        if (content) {
-          console.log("Found observation form content by URL:", content);
-          setSelectedContent(content);
-          setAllPages([content]);
-          setLoading(false);
-          return; // Exit early if we found it
-        }
-        
-        // If no content found by URL, try getAll as fallback
-        return builder.getAll("page", {
+    builder.init(apiKey);
+    
+    setTimeout(async () => {
+      setDebugInfo({
+        hasApiKey: !!apiKey,
+        apiKeyLength: apiKey?.length || 0,
+        nodeEnv: process.env.NODE_ENV,
+        builderInitialized: !!builder.apiKey,
+      });
+
+      try {
+        const pages = await builder.getAll("page", {
           limit: 50,
           includeRefs: true,
         });
-      })
-      .then((pages) => {
-        // Only process this if we didn't already find content above
-        if (selectedContent) return;
-        
-        if (pages && Array.isArray(pages)) {
-          console.log("All Builder.io pages:", pages);
-          setAllPages(pages);
 
-          // Look for "ObservationForm" content
-          const observationPage = pages.find(
-            (p) =>
-              p.name?.toLowerCase().includes("observationform") ||
-              p.name === "ObservationForm" ||
-              p.name?.toLowerCase().includes("observation") ||
-              p.data?.url === "/observation-form"
-          );
+        console.log("Builder.io pages:", pages);
+        setAllPages(pages || []);
 
-          if (observationPage) {
-            console.log("Found observation page:", observationPage);
-            setSelectedContent(observationPage);
-          }
+        if (!pages || pages.length === 0) {
+          setError("No content found in Builder.io. Please check your API key and published content.");
+          setLoading(false);
+          return;
         }
+
+        const observationPage = pages.find(
+          (p) =>
+            p.name?.toLowerCase().includes("observationform") ||
+            p.name === "ObservationForm" ||
+            p.name?.toLowerCase().includes("observation")
+        );
+
+        if (observationPage) {
+          setSelectedContent(observationPage);
+        }
+
         setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Builder fetch error:", err);
-        setError(`Failed to fetch Builder.io content: ${err.message}`);
+      } catch (err) {
+        setError(`Failed to fetch Builder.io content: ${err.message || err}`);
         setLoading(false);
-      });
+      }
+    }, 100);
   }, []);
 
   const handleSelectPage = (page: any) => {
     setSelectedContent(page);
   };
 
-  // Loading state
   if (loading) {
-    return <div>Loading Builder.io Content...</div>;
+    return (Loading Builder.io Content...</h</div
   }
 
-  // Error state
   if (error) {
-    return (
-      <div>
-        <h2 style={{ color: "red" }}>Builder.io Connection Error</h2>
-        <p>{error}</p>
-        <h3>Debug Information:</h3>
-        <pre>{JSON.stringify(debugInfo, null, 2)}</pre>
-      </div>
-    );
+    return (❌ Builder.io Error</h1{error}Debug Information:{JSON.stringify(debugInfo, null, 2)});
   }
 
-  // Content found and selected
   if (selectedContent) {
-    return (
-      <div>
-        {/* Status bar */}
-        <div className="mb-4 flex items-center gap-2">
-          <span role="img" aria-label="success">✅</span>
-          Builder.io Content Loaded: <strong>{selectedContent.name}</strong>
-        </div>
-        <button
-          onClick={() => setSelectedContent(null)}
-          className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
-        >
-          ← Back to Page List
-        </button>
-        {/* Render Builder.io content */}
-        <div className="mt-6 border rounded p-4 bg-white shadow">
-          <BuilderComponent model="page" content={selectedContent} />
-        </div>
-      </div>
-    );
+    return (✅Builder.io Content Loaded:{selectedContent.name}setSelectedContent(null)}
+              className="mt-2 px-3 py-1 bg-green-600 text-white rounded text-sm hover:bg-green-700"
+            >
+              ← Back to Page List</button);
   }
 
-  // Page list view
-  return (
-    <div>
-      <h1>Builder.io Content Finder</h1>
-      <h2>Looking for &quot;ObservationForm&quot;</h2>
-      <p>
-        No content automatically matched. Please select your observation form from the list below:
-      </p>
-      <h2>
-        Available Builder.io Pages ({allPages.length})
-      </h2>
-      {allPages.length === 0 ? (
-        <div>
-          <p>No pages found in your Builder.io space.</p>
-          <p>Make sure you have created and published content in Builder.io.</p>
-        </div>
-      ) : (
-        <div>
-          {allPages.map((page: any, index: number) => (
-            <div key={page.id || index} className="mb-4 p-4 border rounded bg-gray-50">
-              <div>
-                <strong>{page.name || "Untitled Page"}</strong>
-              </div>
-              <div>ID: {page.id}</div>
-              <div>URL: {page.data?.url || "No URL set"}</div>
-              <div>
-                Created:{" "}
-                <strong>
-                  {page.createdDate
-                    ? new Date(page.createdDate).toLocaleDateString()
-                    : "Unknown"}
-                </strong>
-              </div>
-              <div>
-                Updated:{" "}
-                <strong>
-                  {page.lastUpdated
-                    ? new Date(page.lastUpdated).toLocaleDateString()
-                    : "Unknown"}
-                </strong>
-              </div>
-              {/* Highlight potential matches */}
-              {(page.name?.toLowerCase().includes("observationform") ||
-                page.name?.toLowerCase().includes("observation")) && (
-                <div className="text-green-700 font-semibold mt-2">
-                  🎯 Potential Match
-                </div>
-              )}
-              <button
-                onClick={() => handleSelectPage(page)}
-                className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
-              >
-                Load This Page
-              </button>
-            </div>
-          ))}
-        </div>
-      )}
-      {/* Debug info */}
-      <details className="mt-6">
-        <summary>🔧 Debug Information (Click to expand)</summary>
-        <pre>
-          {JSON.stringify(
-            {
-              ...debugInfo,
-              totalPages: allPages.length,
-              searchTerms: ["observationform", "observation", "/observation-form"],
-            },
-            null,
-            2,
-          )}
-        </pre>
-      </details>
-    </div>
-  );
+  return (🔍 Builder.io Content FinderAvailable Builder.io Pages ({allPages.length}){allPages.map((page, index) => ({page.name || "Untitled Page"}ID:{page.id}URL:{page.data?.url || "No URL set"}{(page.name?.toLowerCase().includes("observationform") || page.name?.toLowerCase().includes("observation")) && (🎯 Potential Match)}handleSelectPage(page)}
+                    className="ml-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition-colors"
+                  >
+                    Load This Page))}</div);
 }

--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -1,0 +1,7 @@
+// src/app/observation-form/page.tsx
+import BuilderClientPage from "@/components/BuilderClientPage";
+
+export default function Standards() {
+  // slug must match Builder page URL
+  return <BuilderClientPage slug="/standards" />;
+}

--- a/src/components/builder-content.tsx
+++ b/src/components/builder-content.tsx
@@ -23,3 +23,4 @@ export function RenderBuilderContent({
     />
   );
 }
+ ``


### PR DESCRIPTION
Changes Builder.io integration to use the EngageX model instead of the page model.

Updates include:
- Changed builder.getAll() calls from "page" to "EngageX" model
- Updated BuilderComponent model prop to use "EngageX"
- Modified search logic to look for "ObservationForm" instead of "Mark's observation 2"
- Updated console logs and UI text to reference EngageX content
- Changed search terms from ["mark", "observation", "/observation-form"] to ["observationform", "observation"]
- Updated error messages to mention EngageX model specifically

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/swoosh-works)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>swoosh-works</branchName>-->