### PR TITLE
Add CSV bulk upload functionality for standards

### DIFF
--- a/lib/csv-utils.ts
+++ b/lib/csv-utils.ts
@@ -1,0 +1,321 @@
+export interface StandardCsvRow {
+  organizationName: string;
+  organizationCode: string;
+  facilityName: string;
+  facilityRef?: string;
+  facilityCity?: string;
+  departmentName: string;
+  areaName: string;
+  standardName: string;
+  // UOM entries (up to 75)
+  [key: `uom${number}_name`]: string;
+  [key: `uom${number}_description`]: string;
+  [key: `uom${number}_samValue`]: string;
+  [key: `uom${number}_tags`]: string;
+  // Best practices (up to 20)
+  [key: `bestPractice${number}`]: string;
+  // Process opportunities (up to 20)
+  [key: `processOpportunity${number}`]: string;
+}
+
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+export interface ParsedStandardData {
+  organizationName: string;
+  organizationCode: string;
+  facilityName: string;
+  facilityRef?: string;
+  facilityCity?: string;
+  departmentName: string;
+  areaName: string;
+  standardName: string;
+  uomEntries: Array<{
+    uom: string;
+    description: string;
+    samValue: number;
+    tags: string[];
+  }>;
+  bestPractices: string[];
+  processOpportunities: string[];
+}
+
+export const CSV_LIMITS = {
+  MAX_UOM_ENTRIES: 75,
+  MAX_BEST_PRACTICES: 20,
+  MAX_PROCESS_OPPORTUNITIES: 20,
+};
+
+export function generateCsvTemplate(): string {
+  const headers = [
+    // Required hierarchy fields
+    "organizationName",
+    "organizationCode",
+    "facilityName",
+    "facilityRef",
+    "facilityCity",
+    "departmentName",
+    "areaName",
+    "standardName",
+  ];
+
+  // Add UOM headers (up to 75)
+  for (let i = 1; i <= CSV_LIMITS.MAX_UOM_ENTRIES; i++) {
+    headers.push(`uom${i}_name`);
+    headers.push(`uom${i}_description`);
+    headers.push(`uom${i}_samValue`);
+    headers.push(`uom${i}_tags`);
+  }
+
+  // Add best practices headers (up to 20)
+  for (let i = 1; i <= CSV_LIMITS.MAX_BEST_PRACTICES; i++) {
+    headers.push(`bestPractice${i}`);
+  }
+
+  // Add process opportunities headers (up to 20)
+  for (let i = 1; i <= CSV_LIMITS.MAX_PROCESS_OPPORTUNITIES; i++) {
+    headers.push(`processOpportunity${i}`);
+  }
+
+  // Create sample row
+  const sampleRow = [
+    "Example Organization",
+    "EXO",
+    "Main Facility",
+    "FAC001",
+    "New York",
+    "Production",
+    "Assembly Line A",
+    "Widget Assembly Standard",
+  ];
+
+  // Add sample UOM data for first few entries
+  sampleRow.push(
+    "Units",
+    "Number of units produced",
+    "0.5",
+    "Production,Quality",
+  );
+  sampleRow.push("Minutes", "Time spent on task", "1.2", "Time,Efficiency");
+  sampleRow.push("Pieces", "Components assembled", "0.8", "Assembly");
+
+  // Fill remaining UOM slots with empty values
+  const remainingUomSlots = (CSV_LIMITS.MAX_UOM_ENTRIES - 3) * 4;
+  for (let i = 0; i < remainingUomSlots; i++) {
+    sampleRow.push("");
+  }
+
+  // Add sample best practices
+  sampleRow.push("Follow safety protocols at all times");
+  sampleRow.push("Maintain clean workspace");
+  sampleRow.push("Use proper lifting techniques");
+
+  // Fill remaining best practice slots
+  for (let i = 3; i < CSV_LIMITS.MAX_BEST_PRACTICES; i++) {
+    sampleRow.push("");
+  }
+
+  // Add sample process opportunities
+  sampleRow.push("Implement visual management system");
+  sampleRow.push("Standardize tool placement");
+
+  // Fill remaining process opportunity slots
+  for (let i = 2; i < CSV_LIMITS.MAX_PROCESS_OPPORTUNITIES; i++) {
+    sampleRow.push("");
+  }
+
+  return [headers.join(","), sampleRow.join(",")].join("\n");
+}
+
+export function parseCsvContent(csvContent: string): StandardCsvRow[] {
+  const lines = csvContent.trim().split("\n");
+  if (lines.length < 2) {
+    throw new Error("CSV must contain at least a header row and one data row");
+  }
+
+  const headers = lines[0].split(",").map((h) => h.trim());
+  const rows: StandardCsvRow[] = [];
+
+  for (let i = 1; i < lines.length; i++) {
+    const values = lines[i].split(",").map((v) => v.trim());
+    const row: any = {};
+
+    headers.forEach((header, index) => {
+      row[header] = values[index] || "";
+    });
+
+    rows.push(row as StandardCsvRow);
+  }
+
+  return rows;
+}
+
+export function validateStandardRow(
+  row: StandardCsvRow,
+  rowIndex: number,
+): ValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  // Validate required fields
+  const requiredFields = [
+    "organizationName",
+    "organizationCode",
+    "facilityName",
+    "departmentName",
+    "areaName",
+    "standardName",
+  ];
+
+  requiredFields.forEach((field) => {
+    if (
+      !row[field as keyof StandardCsvRow] ||
+      (row[field as keyof StandardCsvRow] as string).trim() === ""
+    ) {
+      errors.push(`Row ${rowIndex + 1}: Missing required field '${field}'`);
+    }
+  });
+
+  // Validate UOM entries
+  let uomCount = 0;
+  for (let i = 1; i <= CSV_LIMITS.MAX_UOM_ENTRIES; i++) {
+    const uomName = row[`uom${i}_name` as keyof StandardCsvRow] as string;
+    const uomDesc = row[
+      `uom${i}_description` as keyof StandardCsvRow
+    ] as string;
+    const uomSam = row[`uom${i}_samValue` as keyof StandardCsvRow] as string;
+
+    if (uomName || uomDesc || uomSam) {
+      uomCount++;
+
+      if (!uomName?.trim()) {
+        errors.push(
+          `Row ${rowIndex + 1}: UOM ${i} has description or SAM value but missing name`,
+        );
+      }
+      if (!uomDesc?.trim()) {
+        errors.push(
+          `Row ${rowIndex + 1}: UOM ${i} has name or SAM value but missing description`,
+        );
+      }
+      if (!uomSam?.trim()) {
+        errors.push(
+          `Row ${rowIndex + 1}: UOM ${i} has name or description but missing SAM value`,
+        );
+      } else {
+        const samValue = parseFloat(uomSam);
+        if (isNaN(samValue) || samValue <= 0) {
+          errors.push(
+            `Row ${rowIndex + 1}: UOM ${i} SAM value must be a positive number`,
+          );
+        }
+      }
+    }
+  }
+
+  if (uomCount === 0) {
+    warnings.push(
+      `Row ${rowIndex + 1}: No UOM entries found, standard will have no measurable units`,
+    );
+  }
+
+  // Count best practices
+  let bestPracticeCount = 0;
+  for (let i = 1; i <= CSV_LIMITS.MAX_BEST_PRACTICES; i++) {
+    const practice = row[`bestPractice${i}` as keyof StandardCsvRow] as string;
+    if (practice?.trim()) {
+      bestPracticeCount++;
+    }
+  }
+
+  // Count process opportunities
+  let processOpportunityCount = 0;
+  for (let i = 1; i <= CSV_LIMITS.MAX_PROCESS_OPPORTUNITIES; i++) {
+    const opportunity = row[
+      `processOpportunity${i}` as keyof StandardCsvRow
+    ] as string;
+    if (opportunity?.trim()) {
+      processOpportunityCount++;
+    }
+  }
+
+  if (bestPracticeCount === 0) {
+    warnings.push(`Row ${rowIndex + 1}: No best practices defined`);
+  }
+
+  if (processOpportunityCount === 0) {
+    warnings.push(`Row ${rowIndex + 1}: No process opportunities defined`);
+  }
+
+  return {
+    isValid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+export function transformRowToStandardData(
+  row: StandardCsvRow,
+): ParsedStandardData {
+  // Extract UOM entries
+  const uomEntries = [];
+  for (let i = 1; i <= CSV_LIMITS.MAX_UOM_ENTRIES; i++) {
+    const uomName = row[`uom${i}_name` as keyof StandardCsvRow] as string;
+    const uomDesc = row[
+      `uom${i}_description` as keyof StandardCsvRow
+    ] as string;
+    const uomSam = row[`uom${i}_samValue` as keyof StandardCsvRow] as string;
+    const uomTags = row[`uom${i}_tags` as keyof StandardCsvRow] as string;
+
+    if (uomName?.trim() && uomDesc?.trim() && uomSam?.trim()) {
+      uomEntries.push({
+        uom: uomName.trim(),
+        description: uomDesc.trim(),
+        samValue: parseFloat(uomSam),
+        tags: uomTags
+          ? uomTags
+              .split(";")
+              .map((tag) => tag.trim())
+              .filter((tag) => tag)
+          : [],
+      });
+    }
+  }
+
+  // Extract best practices
+  const bestPractices = [];
+  for (let i = 1; i <= CSV_LIMITS.MAX_BEST_PRACTICES; i++) {
+    const practice = row[`bestPractice${i}` as keyof StandardCsvRow] as string;
+    if (practice?.trim()) {
+      bestPractices.push(practice.trim());
+    }
+  }
+
+  // Extract process opportunities
+  const processOpportunities = [];
+  for (let i = 1; i <= CSV_LIMITS.MAX_PROCESS_OPPORTUNITIES; i++) {
+    const opportunity = row[
+      `processOpportunity${i}` as keyof StandardCsvRow
+    ] as string;
+    if (opportunity?.trim()) {
+      processOpportunities.push(opportunity.trim());
+    }
+  }
+
+  return {
+    organizationName: row.organizationName.trim(),
+    organizationCode: row.organizationCode.trim(),
+    facilityName: row.facilityName.trim(),
+    facilityRef: row.facilityRef?.trim() || undefined,
+    facilityCity: row.facilityCity?.trim() || undefined,
+    departmentName: row.departmentName.trim(),
+    areaName: row.areaName.trim(),
+    standardName: row.standardName.trim(),
+    uomEntries,
+    bestPractices,
+    processOpportunities,
+  };
+}

--- a/src/app/api/standards/template/route.ts
+++ b/src/app/api/standards/template/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { generateCsvTemplate } from "@/lib/csv-utils";
+
+export async function GET() {
+  try {
+    const csvContent = generateCsvTemplate();
+
+    return new NextResponse(csvContent, {
+      status: 200,
+      headers: {
+        "Content-Type": "text/csv",
+        "Content-Disposition": 'attachment; filename="standards-template.csv"',
+        "Cache-Control": "no-cache",
+      },
+    });
+  } catch (error) {
+    console.error("Error generating CSV template:", error);
+    return NextResponse.json(
+      { error: "Failed to generate CSV template" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/standards/upload/route.ts
+++ b/src/app/api/standards/upload/route.ts
@@ -1,0 +1,238 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  parseCsvContent,
+  validateStandardRow,
+  transformRowToStandardData,
+  ParsedStandardData,
+  ValidationResult,
+} from "@/lib/csv-utils";
+import { prisma } from "@/lib/prisma";
+
+interface UploadResult {
+  success: boolean;
+  created: number;
+  errors: string[];
+  warnings: string[];
+  details: Array<{
+    row: number;
+    standardName: string;
+    status: "created" | "error";
+    message?: string;
+  }>;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const file = formData.get("file") as File;
+
+    if (!file) {
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
+    }
+
+    if (!file.name.endsWith(".csv")) {
+      return NextResponse.json(
+        { error: "File must be a CSV" },
+        { status: 400 },
+      );
+    }
+
+    const csvContent = await file.text();
+
+    // Parse CSV content
+    let rows;
+    try {
+      rows = parseCsvContent(csvContent);
+    } catch (parseError) {
+      return NextResponse.json(
+        { error: `Failed to parse CSV: ${parseError}` },
+        { status: 400 },
+      );
+    }
+
+    // Validate all rows first
+    const validationResults: Array<{
+      row: number;
+      validation: ValidationResult;
+      data?: ParsedStandardData;
+    }> = [];
+    const allErrors: string[] = [];
+    const allWarnings: string[] = [];
+
+    for (let i = 0; i < rows.length; i++) {
+      const validation = validateStandardRow(rows[i], i);
+      validationResults.push({ row: i + 1, validation });
+
+      allErrors.push(...validation.errors);
+      allWarnings.push(...validation.warnings);
+
+      if (validation.isValid) {
+        validationResults[i].data = transformRowToStandardData(rows[i]);
+      }
+    }
+
+    // If there are validation errors, return them without processing
+    if (allErrors.length > 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          created: 0,
+          errors: allErrors,
+          warnings: allWarnings,
+          details: [],
+        } as UploadResult,
+        { status: 400 },
+      );
+    }
+
+    // Process each valid row
+    const result: UploadResult = {
+      success: true,
+      created: 0,
+      errors: [],
+      warnings: allWarnings,
+      details: [],
+    };
+
+    for (const { row, data } of validationResults) {
+      if (!data) continue;
+
+      try {
+        await createStandardFromData(data);
+        result.created++;
+        result.details.push({
+          row,
+          standardName: data.standardName,
+          status: "created",
+        });
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : "Unknown error";
+        result.errors.push(
+          `Row ${row}: Failed to create standard - ${errorMessage}`,
+        );
+        result.details.push({
+          row,
+          standardName: data.standardName,
+          status: "error",
+          message: errorMessage,
+        });
+      }
+    }
+
+    result.success = result.errors.length === 0;
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("Error processing CSV upload:", error);
+    return NextResponse.json(
+      { error: "Failed to process CSV upload" },
+      { status: 500 },
+    );
+  }
+}
+
+async function createStandardFromData(data: ParsedStandardData) {
+  return await prisma.$transaction(async (tx) => {
+    // Find or create organization
+    let organization = await tx.organization.findUnique({
+      where: { code: data.organizationCode },
+    });
+
+    if (!organization) {
+      organization = await tx.organization.create({
+        data: {
+          name: data.organizationName,
+          code: data.organizationCode,
+        },
+      });
+    }
+
+    // Find or create facility
+    let facility = await tx.facility.findFirst({
+      where: {
+        name: data.facilityName,
+        organizationId: organization.id,
+      },
+    });
+
+    if (!facility) {
+      facility = await tx.facility.create({
+        data: {
+          name: data.facilityName,
+          ref: data.facilityRef,
+          city: data.facilityCity,
+          organizationId: organization.id,
+        },
+      });
+    }
+
+    // Find or create department
+    let department = await tx.department.findFirst({
+      where: {
+        name: data.departmentName,
+        facilityId: facility.id,
+      },
+    });
+
+    if (!department) {
+      department = await tx.department.create({
+        data: {
+          name: data.departmentName,
+          facilityId: facility.id,
+        },
+      });
+    }
+
+    // Find or create area
+    let area = await tx.area.findFirst({
+      where: {
+        name: data.areaName,
+        departmentId: department.id,
+      },
+    });
+
+    if (!area) {
+      area = await tx.area.create({
+        data: {
+          name: data.areaName,
+          departmentId: department.id,
+        },
+      });
+    }
+
+    // Check if standard already exists
+    const existingStandard = await tx.standard.findFirst({
+      where: {
+        name: data.standardName,
+        areaId: area.id,
+      },
+    });
+
+    if (existingStandard) {
+      throw new Error(
+        `Standard '${data.standardName}' already exists in this area`,
+      );
+    }
+
+    // Create standard with UOM entries
+    const standard = await tx.standard.create({
+      data: {
+        name: data.standardName,
+        facilityId: facility.id,
+        departmentId: department.id,
+        areaId: area.id,
+        bestPractices: data.bestPractices,
+        processOpportunities: data.processOpportunities,
+        uomEntries: {
+          create: data.uomEntries,
+        },
+      },
+      include: {
+        uomEntries: true,
+      },
+    });
+
+    return standard;
+  });
+}

--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -124,6 +124,11 @@ export default function Standards() {
   ]);
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);
 
+  // CSV Upload state
+  const [csvFile, setCsvFile] = useState<File | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [uploadResult, setUploadResult] = useState<any>(null);
+
   // Load data from API
   const loadOrganizations = async () => {
     try {

--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -727,6 +727,139 @@ export default function Standards() {
               </div>
             )}
 
+            {/* CSV Upload Section */}
+            <div className="bg-blue-50 p-6 rounded-xl border border-blue-200 shadow-md mb-6">
+              <h2 className="text-xl font-semibold mb-4 text-blue-800">
+                Bulk Standard Upload
+              </h2>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    Upload CSV File
+                  </label>
+                  <input
+                    id="csv-upload"
+                    type="file"
+                    accept=".csv"
+                    onChange={handleCsvFileChange}
+                    disabled={isUploading}
+                    className="w-full p-2 border border-gray-300 rounded-md bg-white disabled:opacity-50"
+                  />
+                  <p className="text-sm text-gray-600 mt-1">
+                    Upload multiple standards at once. Max: 75 UOMs, 20 Best
+                    Practices, 20 Process Opportunities per standard.
+                  </p>
+                </div>
+                <div className="flex flex-col gap-3">
+                  <button
+                    onClick={downloadCsvTemplate}
+                    disabled={isLoading}
+                    className="px-4 py-2 bg-blue-500 text-white border-none rounded-md cursor-pointer font-semibold hover:bg-blue-600 disabled:opacity-50"
+                  >
+                    📥 Download Template
+                  </button>
+                  <button
+                    onClick={uploadCsvFile}
+                    disabled={!csvFile || isUploading}
+                    className="px-4 py-2 bg-green-500 text-white border-none rounded-md cursor-pointer font-semibold hover:bg-green-600 disabled:opacity-50"
+                  >
+                    {isUploading ? "Uploading..." : "🚀 Upload Standards"}
+                  </button>
+                </div>
+              </div>
+
+              {/* Upload Results */}
+              {uploadResult && (
+                <div
+                  className={`p-4 rounded-lg border ${uploadResult.success ? "bg-green-50 border-green-200" : "bg-red-50 border-red-200"}`}
+                >
+                  <h3
+                    className={`font-semibold mb-2 ${uploadResult.success ? "text-green-800" : "text-red-800"}`}
+                  >
+                    Upload Results
+                  </h3>
+
+                  {uploadResult.success && (
+                    <p className="text-green-700 mb-2">
+                      ✅ Successfully created {uploadResult.created} standards
+                    </p>
+                  )}
+
+                  {uploadResult.errors?.length > 0 && (
+                    <div className="mb-3">
+                      <h4 className="font-medium text-red-700 mb-1">Errors:</h4>
+                      <ul className="text-sm text-red-600 space-y-1">
+                        {uploadResult.errors.map(
+                          (error: string, index: number) => (
+                            <li key={index}>• {error}</li>
+                          ),
+                        )}
+                      </ul>
+                    </div>
+                  )}
+
+                  {uploadResult.warnings?.length > 0 && (
+                    <div className="mb-3">
+                      <h4 className="font-medium text-yellow-700 mb-1">
+                        Warnings:
+                      </h4>
+                      <ul className="text-sm text-yellow-600 space-y-1">
+                        {uploadResult.warnings.map(
+                          (warning: string, index: number) => (
+                            <li key={index}>• {warning}</li>
+                          ),
+                        )}
+                      </ul>
+                    </div>
+                  )}
+
+                  {uploadResult.details?.length > 0 && (
+                    <div>
+                      <h4 className="font-medium text-gray-700 mb-1">
+                        Details:
+                      </h4>
+                      <div className="max-h-32 overflow-y-auto">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="bg-gray-100">
+                              <th className="px-2 py-1 text-left">Row</th>
+                              <th className="px-2 py-1 text-left">Standard</th>
+                              <th className="px-2 py-1 text-left">Status</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {uploadResult.details.map(
+                              (detail: any, index: number) => (
+                                <tr key={index} className="border-b">
+                                  <td className="px-2 py-1">{detail.row}</td>
+                                  <td className="px-2 py-1">
+                                    {detail.standardName}
+                                  </td>
+                                  <td className="px-2 py-1">
+                                    <span
+                                      className={
+                                        detail.status === "created"
+                                          ? "text-green-600"
+                                          : "text-red-600"
+                                      }
+                                    >
+                                      {detail.status === "created"
+                                        ? "✅ Created"
+                                        : "❌ Error"}
+                                    </span>
+                                  </td>
+                                </tr>
+                              ),
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             <div className="bg-gray-100 p-6 rounded-xl border border-gray-300 shadow-md">
               <h2 className="text-xl font-semibold mb-6">
                 Standard Transformation


### PR DESCRIPTION
This pull request adds comprehensive CSV bulk upload functionality for standards management.

**New Files Added:**
- `lib/csv-utils.ts` - Core CSV utilities with interfaces, validation, and parsing functions
- `src/app/api/standards/template/route.ts` - API endpoint for downloading CSV templates

**Key Features:**
- CSV template generation with support for up to 75 UOM entries, 20 best practices, and 20 process opportunities per standard
- CSV parsing and validation with comprehensive error checking
- Row-by-row validation for required fields, UOM entries, and data integrity
- Data transformation from CSV format to structured standard data

**UI Enhancements:**
- Added CSV upload section to standards page with file input and upload controls
- Download template button for users to get properly formatted CSV files
- Upload results display showing success/error status, warnings, and detailed processing information
- Real-time feedback during upload process with loading states

**Database Integration:**
- Bulk standard creation with proper hierarchy validation (organization → facility → department → area)
- Automatic UOM entry creation linked to standards
- Duplicate standard detection within the same area

**Validation Features:**
- Required field validation for organizational hierarchy
- UOM entry completeness checking (name, description, SAM value)
- Numeric validation for SAM values
- Warning system for missing best practices or process opportunities

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 23`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/curry-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>curry-zone</branchName>-->