### PR TITLE
Add helper text to organization and facility selects

### DIFF
--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -865,37 +865,59 @@ export default function Standards() {
                 Standard Transformation
               </h2>
               <div className="grid grid-cols-5 gap-4 mb-6">
-                <select
-                  value={selectedOrganization}
-                  onChange={(e) => {
-                    setSelectedOrganization(e.target.value);
-                  }}
-                  disabled={isLoading}
-                  className="w-full p-2 rounded-md border border-gray-300 bg-white disabled:opacity-50"
-                >
-                  <option value="">Select Organization</option>
-                  {organizations.map((organization) => (
-                    <option value={organization.id} key={organization.id}>
-                      {organization.name}
-                    </option>
-                  ))}
-                </select>
+                <div className="relative">
+                  <select
+                    value={selectedOrganization}
+                    onChange={(e) => {
+                      setSelectedOrganization(e.target.value);
+                    }}
+                    disabled={isLoading}
+                    className="w-full p-2 rounded-md border border-gray-300 bg-white disabled:opacity-50"
+                  >
+                    <option value="">Select Organization</option>
+                    {organizations.map((organization) => (
+                      <option value={organization.id} key={organization.id}>
+                        {organization.name}
+                      </option>
+                    ))}
+                  </select>
+                  {organizations.length === 0 && !isLoading && (
+                    <div className="text-xs text-gray-500 mt-1">
+                      Add an organization first using the form below
+                    </div>
+                  )}
+                </div>
 
-                <select
-                  value={selectedFacility}
-                  disabled={!selectedOrganization || isLoading}
-                  onChange={(e) => {
-                    setSelectedFacility(e.target.value);
-                  }}
-                  className="w-full p-2 rounded-md border border-gray-300 bg-white disabled:opacity-60"
-                >
-                  <option value="">Select Facility</option>
-                  {facilities.map((facility) => (
-                    <option value={facility.id} key={facility.id}>
-                      {facility.name}
-                    </option>
-                  ))}
-                </select>
+                <div className="relative">
+                  <select
+                    value={selectedFacility}
+                    disabled={!selectedOrganization || isLoading}
+                    onChange={(e) => {
+                      setSelectedFacility(e.target.value);
+                    }}
+                    className="w-full p-2 rounded-md border border-gray-300 bg-white disabled:opacity-60"
+                  >
+                    <option value="">Select Facility</option>
+                    {facilities.map((facility) => (
+                      <option value={facility.id} key={facility.id}>
+                        {facility.name}
+                      </option>
+                    ))}
+                  </select>
+                  {selectedOrganization &&
+                    facilities.length === 0 &&
+                    !isLoading && (
+                      <div className="text-xs text-gray-500 mt-1">
+                        Add a facility for this organization using the form
+                        below
+                      </div>
+                    )}
+                  {!selectedOrganization && (
+                    <div className="text-xs text-gray-500 mt-1">
+                      Select an organization first
+                    </div>
+                  )}
+                </div>
 
                 <select
                   value={selectedDepartment}


### PR DESCRIPTION
Wraps organization and facility select elements in relative containers and adds conditional helper text below each dropdown.

Organization select:
- Shows "Add an organization first using the form below" when no organizations exist and not loading

Facility select:
- Shows "Add a facility for this organization using the form below" when organization is selected but no facilities exist and not loading
- Shows "Select an organization first" when no organization is selected

Helper text uses text-xs text-gray-500 mt-1 styling for consistent appearance.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 25`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/cosmos-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>cosmos-oasis</branchName>-->