### PR TITLE
Add error handling for duplicate organization codes

### DIFF
--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -268,10 +268,18 @@ export default function Standards() {
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
+        if (response.status === 409) {
+          setError(
+            errorData.error ||
+              "Organization code already exists. Please use a different code.",
+          );
+          return;
+        }
         const errorMessage =
           errorData.error ||
           `Failed to create organization (${response.status})`;
-        throw new Error(errorMessage);
+        setError(errorMessage);
+        return;
       }
 
       await loadOrganizations();


### PR DESCRIPTION
Add specific error handling for HTTP 409 status code when creating organizations.

Changes:
- Check for 409 status code and display appropriate error message for duplicate organization codes
- Replace throw statement with setError call to handle errors gracefully
- Add early return statements to prevent further execution after error handling

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 29`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/glow-home)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>glow-home</branchName>-->