### PR TITLE
Update PUMP score calculation and add increment buttons

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1049,15 +1049,35 @@ export default function GazeObservationApp() {
                   <label className="block mb-2 font-medium text-center">
                     Pace
                   </label>
-                  <input
-                    type="number"
-                    min="1"
-                    max="200"
-                    value={pace}
-                    onChange={(e) => setPace(parseInt(e.target.value) || 100)}
-                    disabled={!isObserving}
-                    className="w-full p-3 rounded-lg border border-gray-300 disabled:opacity-50 text-center"
-                  />
+                  <div className="flex items-center justify-center gap-2">
+                    <button
+                      disabled={!isObserving || pace <= 5}
+                      onClick={() => setPace(Math.max(5, pace - 5))}
+                      className="p-2 rounded bg-blue-500 text-white cursor-pointer disabled:opacity-50 disabled:bg-gray-300 hover:bg-blue-600 flex items-center justify-center w-8 h-8"
+                    >
+                      -
+                    </button>
+                    <input
+                      type="number"
+                      min="5"
+                      max="200"
+                      step="5"
+                      value={pace}
+                      onChange={(e) => {
+                        const value = parseInt(e.target.value) || 100;
+                        setPace(Math.round(value / 5) * 5);
+                      }}
+                      disabled={!isObserving}
+                      className="w-full p-3 rounded-lg border border-gray-300 disabled:opacity-50 text-center"
+                    />
+                    <button
+                      disabled={!isObserving || pace >= 200}
+                      onClick={() => setPace(Math.min(200, pace + 5))}
+                      className="p-2 rounded bg-blue-500 text-white cursor-pointer disabled:opacity-50 disabled:bg-gray-300 hover:bg-blue-600 flex items-center justify-center w-8 h-8"
+                    >
+                      +
+                    </button>
+                  </div>
                 </div>
 
                 {/* Multiplication Symbol */}
@@ -1070,17 +1090,41 @@ export default function GazeObservationApp() {
                   <label className="block mb-2 font-medium text-center">
                     Utilization
                   </label>
-                  <input
-                    type="number"
-                    min="1"
-                    max="200"
-                    value={utilization}
-                    onChange={(e) =>
-                      setUtilization(parseInt(e.target.value) || 100)
-                    }
-                    disabled={!isObserving}
-                    className="w-full p-3 rounded-lg border border-gray-300 disabled:opacity-50 text-center"
-                  />
+                  <div className="flex items-center justify-center gap-2">
+                    <button
+                      disabled={!isObserving || utilization <= 5}
+                      onClick={() =>
+                        setUtilization(Math.max(5, utilization - 5))
+                      }
+                      className="p-2 rounded bg-blue-500 text-white cursor-pointer disabled:opacity-50 disabled:bg-gray-300 hover:bg-blue-600 flex items-center justify-center w-8 h-8"
+                    >
+                      -
+                    </button>
+                    <input
+                      type="number"
+                      min="5"
+                      max="100"
+                      step="5"
+                      value={utilization}
+                      onChange={(e) => {
+                        const value = parseInt(e.target.value) || 100;
+                        setUtilization(
+                          Math.min(100, Math.round(value / 5) * 5),
+                        );
+                      }}
+                      disabled={!isObserving}
+                      className="w-full p-3 rounded-lg border border-gray-300 disabled:opacity-50 text-center"
+                    />
+                    <button
+                      disabled={!isObserving || utilization >= 100}
+                      onClick={() =>
+                        setUtilization(Math.min(100, utilization + 5))
+                      }
+                      className="p-2 rounded bg-blue-500 text-white cursor-pointer disabled:opacity-50 disabled:bg-gray-300 hover:bg-blue-600 flex items-center justify-center w-8 h-8"
+                    >
+                      +
+                    </button>
+                  </div>
                 </div>
 
                 {/* Multiplication Symbol */}
@@ -1093,17 +1137,35 @@ export default function GazeObservationApp() {
                   <label className="block mb-2 font-medium text-center">
                     Methods and Procedures
                   </label>
-                  <input
-                    type="number"
-                    min="1"
-                    max="200"
-                    value={methods}
-                    onChange={(e) =>
-                      setMethods(parseInt(e.target.value) || 100)
-                    }
-                    disabled={!isObserving}
-                    className="w-full p-3 rounded-lg border border-gray-300 disabled:opacity-50 text-center"
-                  />
+                  <div className="flex items-center justify-center gap-2">
+                    <button
+                      disabled={!isObserving || methods <= 5}
+                      onClick={() => setMethods(Math.max(5, methods - 5))}
+                      className="p-2 rounded bg-blue-500 text-white cursor-pointer disabled:opacity-50 disabled:bg-gray-300 hover:bg-blue-600 flex items-center justify-center w-8 h-8"
+                    >
+                      -
+                    </button>
+                    <input
+                      type="number"
+                      min="5"
+                      max="200"
+                      step="5"
+                      value={methods}
+                      onChange={(e) => {
+                        const value = parseInt(e.target.value) || 100;
+                        setMethods(Math.round(value / 5) * 5);
+                      }}
+                      disabled={!isObserving}
+                      className="w-full p-3 rounded-lg border border-gray-300 disabled:opacity-50 text-center"
+                    />
+                    <button
+                      disabled={!isObserving || methods >= 200}
+                      onClick={() => setMethods(Math.min(200, methods + 5))}
+                      className="p-2 rounded bg-blue-500 text-white cursor-pointer disabled:opacity-50 disabled:bg-gray-300 hover:bg-blue-600 flex items-center justify-center w-8 h-8"
+                    >
+                      +
+                    </button>
+                  </div>
                 </div>
 
                 {/* Equals Symbol */}

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -418,10 +418,9 @@ export default function GazeObservationApp() {
       const performance = (totalSams / timeObserved) * 100;
       setObservedPerformance(Number(performance.toFixed(2)));
     }
-    // Calculate PUMP score and round to nearest 5% increment
+    // Calculate PUMP score as straight multiplication
     const score = (pace * utilization * methods) / 10000;
-    const roundedScore = Math.round(score / 5) * 5;
-    setPumpScore(roundedScore);
+    setPumpScore(Number(score.toFixed(1)));
   };
 
   const updateQuantity = (id: number, value: number) => {


### PR DESCRIPTION
Changes PUMP score calculation from rounding to nearest 5% to straight multiplication with 1 decimal place precision.

Replaces simple number inputs for Pace, Utilization, and Methods with increment/decrement button controls:
- Adds +/- buttons for each input field
- Enforces 5-unit increments for all values
- Sets minimum values to 5 for all fields
- Limits Utilization maximum to 100
- Maintains existing maximum of 200 for Pace and Methods
- Buttons are disabled when at min/max values or when not observing

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 38`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/flare-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>flare-garden</branchName>-->