### PR TITLE
Add Banner component to observation and standards pages

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
+import { Banner } from "@/components/ui/Banner";
 
 type Row = {
   id: number;
@@ -791,6 +792,10 @@ export default function GazeObservationApp() {
 
   return (
     <div className="font-poppins text-black bg-gray-100 min-h-screen overflow-x-hidden">
+      <Banner
+        title="Observation Form"
+        subtitle="Complete work sampling observations and performance analysis"
+      />
       <div className="flex flex-col max-w-7xl mx-auto bg-gray-100 min-h-[calc(100vh-80px)] rounded-xl border border-gray-300 mt-5 p-5 overflow-y-auto">
         <div className="flex flex-row h-full">
           <div

--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { Banner } from "@/components/ui/Banner";
 
 interface Organization {
   id: number;

--- a/src/app/standards/page.tsx
+++ b/src/app/standards/page.tsx
@@ -722,6 +722,10 @@ export default function Standards() {
 
   return (
     <div className="font-poppins text-black bg-gray-100 min-h-screen overflow-x-hidden">
+      <Banner
+        title="Standards Management"
+        subtitle="Manage and configure work standards for facilities and departments"
+      />
       <div className="flex flex-col max-w-7xl mx-auto bg-gray-100 min-h-[calc(100vh-80px)] rounded-xl border border-gray-300 mt-5 p-5 overflow-y-auto">
         <div className="flex flex-row h-full">
           <div

--- a/src/components/ui/Banner.tsx
+++ b/src/components/ui/Banner.tsx
@@ -1,0 +1,20 @@
+interface BannerProps {
+  title: string;
+  subtitle?: string;
+  className?: string;
+}
+
+export function Banner({ title, subtitle, className = "" }: BannerProps) {
+  return (
+    <div
+      className={`bg-gradient-to-r from-blue-600 to-blue-800 text-white py-6 px-8 mb-5 rounded-lg shadow-lg ${className}`}
+    >
+      <div className="max-w-7xl mx-auto">
+        <h1 className="text-2xl md:text-3xl font-bold mb-2">{title}</h1>
+        {subtitle && (
+          <p className="text-blue-100 text-lg opacity-90">{subtitle}</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This change adds a new Banner component and integrates it into two existing pages:

- Created new Banner component in `src/components/ui/Banner.tsx` with title, subtitle, and optional className props
- Added Banner to observation form page with title "Observation Form" and subtitle describing work sampling observations
- Added Banner to standards page with title "Standards Management" and subtitle describing work standards management
- Banner features a blue gradient background with white text and responsive design

The Banner component provides consistent page headers across the application with clear titles and descriptive subtitles.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 39`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/aura-works)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>aura-works</branchName>-->