### PR TITLE
Refactor sidebar into reusable component

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
 import { Banner } from "@/components/ui/Banner";
+import { Sidebar } from "@/components/Sidebar";
 
 export default function AdminPage() {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -4,8 +4,6 @@ import { Banner } from "@/components/ui/Banner";
 import { Sidebar } from "@/components/Sidebar";
 
 export default function AdminPage() {
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);
-
   return (
     <div className="min-h-screen bg-gray-50">
       <Banner
@@ -14,99 +12,36 @@ export default function AdminPage() {
       />
 
       <div className="flex flex-row h-full">
-        <div
-          className="bg-white border-r border-gray-300 transition-all duration-300 flex flex-col justify-between relative shadow-md"
-          style={{
-            width: isSidebarCollapsed ? "80px" : "300px",
-            padding: isSidebarCollapsed ? "24px 12px" : "24px",
-          }}
-        >
-          <div>
-            <div
-              className="flex items-center gap-3 mb-8"
-              style={{
-                justifyContent: isSidebarCollapsed ? "center" : "flex-start",
-              }}
-            >
-              <button
-                onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-                className="absolute -right-3 top-6 w-6 h-6 rounded-full border border-gray-300 bg-white cursor-pointer flex items-center justify-center transition-transform duration-300"
-                style={{
-                  transform: isSidebarCollapsed
-                    ? "rotate(180deg)"
-                    : "rotate(0deg)",
-                }}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M10 2L4 8L10 14"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </button>
-              <span
-                className="text-xl font-semibold"
-                style={{ display: isSidebarCollapsed ? "none" : "block" }}
-              >
-                Guardian Admin
-              </span>
-            </div>
-
-            {!isSidebarCollapsed && (
-              <div className="space-y-4">
-                <div className="text-sm text-gray-600">
-                  <h3 className="font-semibold mb-2">User Management</h3>
-                  <ul className="space-y-2">
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Users
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Roles & Permissions
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Access Control
-                    </li>
-                  </ul>
-                </div>
-
-                <div className="text-sm text-gray-600">
-                  <h3 className="font-semibold mb-2">System Settings</h3>
-                  <ul className="space-y-2">
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Organizations
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Facilities
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Departments
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Configuration
-                    </li>
-                  </ul>
-                </div>
-
-                <div className="text-sm text-gray-600">
-                  <h3 className="font-semibold mb-2">Maintenance</h3>
-                  <ul className="space-y-2">
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      System Logs
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Data Backup
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Database Tools
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
+        <Sidebar
+          title="Guardian Admin"
+          sections={[
+            {
+              title: "User Management",
+              items: [
+                { label: "Users" },
+                { label: "Roles & Permissions" },
+                { label: "Access Control" },
+              ],
+            },
+            {
+              title: "System Settings",
+              items: [
+                { label: "Organizations" },
+                { label: "Facilities" },
+                { label: "Departments" },
+                { label: "Configuration" },
+              ],
+            },
+            {
+              title: "Maintenance",
+              items: [
+                { label: "System Logs" },
+                { label: "Data Backup" },
+                { label: "Database Tools" },
+              ],
+            },
+          ]}
+        />
 
         <main className="flex-1 p-6 bg-white overflow-x-auto overflow-y-auto min-w-0">
           <div className="flex justify-between items-center mb-6">

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -798,114 +798,21 @@ export default function GazeObservationApp() {
       />
       <div className="flex flex-col max-w-7xl mx-auto bg-gray-100 min-h-[calc(100vh-80px)] rounded-xl border border-gray-300 mt-5 p-5 overflow-y-auto">
         <div className="flex flex-row h-full">
-          <div
-            className="bg-white border-r border-gray-300 transition-all duration-300 flex flex-col justify-between relative shadow-md"
-            style={{
-              width: isSidebarCollapsed ? "80px" : "300px",
-              padding: isSidebarCollapsed ? "24px 12px" : "24px",
-            }}
-          >
-            <div>
-              <div
-                className="flex items-center gap-3 mb-8"
-                style={{
-                  justifyContent: isSidebarCollapsed ? "center" : "flex-start",
-                }}
-              >
-                <button
-                  onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-                  className="absolute -right-3 top-6 w-6 h-6 rounded-full border border-gray-300 bg-white cursor-pointer flex items-center justify-center transition-transform duration-300"
-                  style={{
-                    transform: isSidebarCollapsed
-                      ? "rotate(180deg)"
-                      : "rotate(0deg)",
-                  }}
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                    <path
-                      d="M10 2L4 8L10 14"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                </button>
-                <img
-                  loading="lazy"
-                  srcSet="https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=100 100w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=200 200w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=400 400w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=800 800w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02"
-                  style={{
-                    aspectRatio: "0.46",
-                    objectFit: "cover",
-                    objectPosition: "center",
-                    width: "100%",
-                    marginLeft: "20px",
-                    minHeight: "20px",
-                    minWidth: "20px",
-                    overflow: "hidden",
-                    maxWidth: "189px",
-                    display: isSidebarCollapsed ? "none" : "block",
-                  }}
-                />
-              </div>
-
-              {/* Available Applications */}
-              {!isSidebarCollapsed && (
-                <div className="mt-6">
-                  <h3 className="text-sm font-semibold mb-4 text-gray-700">
-                    Available Applications
-                  </h3>
-                  <div className="space-y-2">
-                    {[
-                      "Labor.X",
-                      "Clock.X",
-                      "Engage.X",
-                      "Staff.X",
-                      "Dash.X",
-                      "Report.X",
-                      "Incent.X",
-                      "Perform.X",
-                      "Plan.X",
-                    ].map((app) => (
-                      <div
-                        key={app}
-                        className="py-2 px-3 bg-gray-50 rounded hover:bg-red-50 transition-colors cursor-pointer border border-gray-100 hover:border-red-200"
-                      >
-                        <div className="font-montserrat text-lg font-medium text-gray-800">
-                          {app}
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-
-            {/* User Profile Section */}
-            {!isSidebarCollapsed && (
-              <div className="border-t border-gray-200 pt-4">
-                <div className="flex items-center gap-3 mb-3">
-                  <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center overflow-hidden">
-                    <img
-                      src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=96&h=96&fit=crop&crop=face"
-                      alt="User Profile"
-                      className="w-full h-full object-cover"
-                    />
-                  </div>
-                  <div className="flex-1">
-                    <div className="font-semibold text-gray-800 text-sm">
-                      John Smith
-                    </div>
-                    <a
-                      href="/profile"
-                      className="text-xs text-red-600 hover:text-red-800 transition-colors cursor-pointer"
-                    >
-                      View Profile
-                    </a>
-                  </div>
-                </div>
-              </div>
-            )}
-          </div>
+          <Sidebar
+            showLogo={true}
+            applications={[
+              "Labor.X",
+              "Clock.X",
+              "Engage.X",
+              "Staff.X",
+              "Dash.X",
+              "Report.X",
+              "Incent.X",
+              "Perform.X",
+              "Plan.X",
+            ]}
+            showUserProfile={true}
+          />
 
           <main className="flex-1 p-6 bg-white overflow-x-auto overflow-y-auto min-w-0">
             <div className="flex justify-between items-center mb-6">

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { Banner } from "@/components/ui/Banner";
+import { Sidebar } from "@/components/Sidebar";
 
 type Row = {
   id: number;

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -830,12 +830,22 @@ export default function GazeObservationApp() {
                     />
                   </svg>
                 </button>
-                <span
-                  className="text-xl font-semibold"
-                  style={{ display: isSidebarCollapsed ? "none" : "block" }}
-                >
-                  Gaze Observation
-                </span>
+                <img
+                  loading="lazy"
+                  srcSet="https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=100 100w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=200 200w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=400 400w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=800 800w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02"
+                  style={{
+                    aspectRatio: "0.46",
+                    objectFit: "cover",
+                    objectPosition: "center",
+                    width: "100%",
+                    marginLeft: "20px",
+                    minHeight: "20px",
+                    minWidth: "20px",
+                    overflow: "hidden",
+                    maxWidth: "189px",
+                    display: isSidebarCollapsed ? "none" : "block",
+                  }}
+                />
               </div>
 
               {/* Available Applications */}

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -128,7 +128,6 @@ export default function GazeObservationApp() {
   const [showPreviousObservations, setShowPreviousObservations] =
     useState(false);
   const [showReasonInstructions, setShowReasonInstructions] = useState(false);
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const slides = [

--- a/src/app/reporting/page.tsx
+++ b/src/app/reporting/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Banner } from "@/components/ui/Banner";
+import { Sidebar } from "@/components/Sidebar";
 
 export default function ReportingPage() {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);

--- a/src/app/reporting/page.tsx
+++ b/src/app/reporting/page.tsx
@@ -5,76 +5,25 @@ import { Banner } from "@/components/ui/Banner";
 import { Sidebar } from "@/components/Sidebar";
 
 export default function ReportingPage() {
-  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);
-
   return (
     <div className="min-h-screen bg-gray-50">
       <Banner title="Insight" subtitle="Analytics and Reporting Dashboard" />
 
       <div className="flex flex-row h-full">
-        <div
-          className="bg-white border-r border-gray-300 transition-all duration-300 flex flex-col justify-between relative shadow-md"
-          style={{
-            width: isSidebarCollapsed ? "80px" : "300px",
-            padding: isSidebarCollapsed ? "24px 12px" : "24px",
-          }}
-        >
-          <div>
-            <div
-              className="flex items-center gap-3 mb-8"
-              style={{
-                justifyContent: isSidebarCollapsed ? "center" : "flex-start",
-              }}
-            >
-              <button
-                onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
-                className="absolute -right-3 top-6 w-6 h-6 rounded-full border border-gray-300 bg-white cursor-pointer flex items-center justify-center transition-transform duration-300"
-                style={{
-                  transform: isSidebarCollapsed
-                    ? "rotate(180deg)"
-                    : "rotate(0deg)",
-                }}
-              >
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-                  <path
-                    d="M10 2L4 8L10 14"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              </button>
-              <span
-                className="text-xl font-semibold"
-                style={{ display: isSidebarCollapsed ? "none" : "block" }}
-              >
-                Insight Reporting
-              </span>
-            </div>
-
-            {!isSidebarCollapsed && (
-              <div className="space-y-4">
-                <div className="text-sm text-gray-600">
-                  <h3 className="font-semibold mb-2">Reports</h3>
-                  <ul className="space-y-2">
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Performance Analytics
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Standards Compliance
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Observation Trends
-                    </li>
-                    <li className="cursor-pointer hover:text-red-600 transition-colors">
-                      Department Metrics
-                    </li>
-                  </ul>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
+        <Sidebar
+          title="Insight Reporting"
+          sections={[
+            {
+              title: "Reports",
+              items: [
+                { label: "Performance Analytics" },
+                { label: "Standards Compliance" },
+                { label: "Observation Trends" },
+                { label: "Department Metrics" },
+              ],
+            },
+          ]}
+        />
 
         <main className="flex-1 p-6 bg-white overflow-x-auto overflow-y-auto min-w-0">
           <div className="flex justify-between items-center mb-6">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -142,27 +142,35 @@ export function Sidebar({
       </div>
 
       {/* User Profile Section */}
-      {!isSidebarCollapsed && showUserProfile && (
-        <div className="border-t border-gray-200 pt-4">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center overflow-hidden">
+      {showUserProfile && (
+        <div
+          className={`${!isSidebarCollapsed ? "border-t border-gray-200" : ""} pt-4`}
+        >
+          <div
+            className={`flex items-center ${isSidebarCollapsed ? "justify-center" : "gap-3"} mb-3`}
+          >
+            <div
+              className={`${isSidebarCollapsed ? "w-8 h-8" : "w-12 h-12"} rounded-full bg-red-100 flex items-center justify-center overflow-hidden`}
+            >
               <img
                 src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=96&h=96&fit=crop&crop=face"
                 alt="User Profile"
                 className="w-full h-full object-cover"
               />
             </div>
-            <div className="flex-1">
-              <div className="font-semibold text-gray-800 text-sm">
-                John Smith
+            {!isSidebarCollapsed && (
+              <div className="flex-1">
+                <div className="font-semibold text-gray-800 text-sm">
+                  John Smith
+                </div>
+                <a
+                  href="/profile"
+                  className="text-xs text-red-600 hover:text-red-800 transition-colors cursor-pointer"
+                >
+                  View Profile
+                </a>
               </div>
-              <a
-                href="/profile"
-                className="text-xs text-red-600 hover:text-red-800 transition-colors cursor-pointer"
-              >
-                View Profile
-              </a>
-            </div>
+            )}
           </div>
         </div>
       )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -72,13 +72,13 @@ export function Sidebar({
                 aspectRatio: "0.46",
                 objectFit: "cover",
                 objectPosition: "center",
-                width: "100%",
-                marginLeft: "20px",
+                width: isSidebarCollapsed ? "32px" : "100%",
+                height: isSidebarCollapsed ? "70px" : "auto",
+                marginLeft: isSidebarCollapsed ? "0" : "20px",
                 minHeight: "20px",
                 minWidth: "20px",
                 overflow: "hidden",
-                maxWidth: "189px",
-                display: isSidebarCollapsed ? "none" : "block",
+                maxWidth: isSidebarCollapsed ? "32px" : "189px",
               }}
             />
           ) : (

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+
+interface SidebarMenuItem {
+  label: string;
+  href?: string;
+  onClick?: () => void;
+}
+
+interface SidebarSection {
+  title: string;
+  items: SidebarMenuItem[];
+}
+
+interface SidebarProps {
+  title?: string;
+  showLogo?: boolean;
+  sections?: SidebarSection[];
+  applications?: string[];
+  showUserProfile?: boolean;
+  className?: string;
+}
+
+export function Sidebar({
+  title,
+  showLogo = false,
+  sections = [],
+  applications = [],
+  showUserProfile = false,
+  className = "",
+}: SidebarProps) {
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(true);
+
+  return (
+    <div
+      className={`bg-white border-r border-gray-300 transition-all duration-300 flex flex-col justify-between relative shadow-md ${className}`}
+      style={{
+        width: isSidebarCollapsed ? "80px" : "300px",
+        padding: isSidebarCollapsed ? "24px 12px" : "24px",
+      }}
+    >
+      <div>
+        <div
+          className="flex items-center gap-3 mb-8"
+          style={{
+            justifyContent: isSidebarCollapsed ? "center" : "flex-start",
+          }}
+        >
+          <button
+            onClick={() => setIsSidebarCollapsed(!isSidebarCollapsed)}
+            className="absolute -right-3 top-6 w-6 h-6 rounded-full border border-gray-300 bg-white cursor-pointer flex items-center justify-center transition-transform duration-300"
+            style={{
+              transform: isSidebarCollapsed ? "rotate(180deg)" : "rotate(0deg)",
+            }}
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path
+                d="M10 2L4 8L10 14"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              />
+            </svg>
+          </button>
+
+          {showLogo ? (
+            <img
+              loading="lazy"
+              srcSet="https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=100 100w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=200 200w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=400 400w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=800 800w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=1200 1200w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=1600 1600w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02?width=2000 2000w, https://cdn.builder.io/api/v1/image/assets%2F9ce0f418d64249b18f0cb96e0afc51db%2F981851a2ebf64f97b0e4c0d203be9b02"
+              style={{
+                aspectRatio: "0.46",
+                objectFit: "cover",
+                objectPosition: "center",
+                width: "100%",
+                marginLeft: "20px",
+                minHeight: "20px",
+                minWidth: "20px",
+                overflow: "hidden",
+                maxWidth: "189px",
+                display: isSidebarCollapsed ? "none" : "block",
+              }}
+            />
+          ) : (
+            title && (
+              <span
+                className="text-xl font-semibold"
+                style={{ display: isSidebarCollapsed ? "none" : "block" }}
+              >
+                {title}
+              </span>
+            )
+          )}
+        </div>
+
+        {/* Applications List */}
+        {!isSidebarCollapsed && applications.length > 0 && (
+          <div className="mt-6">
+            <h3 className="text-sm font-semibold mb-4 text-gray-700">
+              Available Applications
+            </h3>
+            <div className="space-y-2">
+              {applications.map((app) => (
+                <div
+                  key={app}
+                  className="py-2 px-3 bg-gray-50 rounded hover:bg-red-50 transition-colors cursor-pointer border border-gray-100 hover:border-red-200"
+                >
+                  <div className="font-montserrat text-lg font-medium text-gray-800">
+                    {app}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Navigation Sections */}
+        {!isSidebarCollapsed && sections.length > 0 && (
+          <div className="space-y-4">
+            {sections.map((section, index) => (
+              <div key={index} className="text-sm text-gray-600">
+                <h3 className="font-semibold mb-2">{section.title}</h3>
+                <ul className="space-y-2">
+                  {section.items.map((item, itemIndex) => (
+                    <li
+                      key={itemIndex}
+                      className="cursor-pointer hover:text-red-600 transition-colors"
+                      onClick={item.onClick}
+                    >
+                      {item.href ? (
+                        <a href={item.href}>{item.label}</a>
+                      ) : (
+                        item.label
+                      )}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* User Profile Section */}
+      {!isSidebarCollapsed && showUserProfile && (
+        <div className="border-t border-gray-200 pt-4">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center overflow-hidden">
+              <img
+                src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?w=96&h=96&fit=crop&crop=face"
+                alt="User Profile"
+                className="w-full h-full object-cover"
+              />
+            </div>
+            <div className="flex-1">
+              <div className="font-semibold text-gray-800 text-sm">
+                John Smith
+              </div>
+              <a
+                href="/profile"
+                className="text-xs text-red-600 hover:text-red-800 transition-colors cursor-pointer"
+              >
+                View Profile
+              </a>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Extract inline sidebar implementations into a reusable Sidebar component.

Changes made:
- Created new Sidebar component in src/components/Sidebar.tsx
- Replaced duplicate sidebar code in admin page with Sidebar component
- Replaced duplicate sidebar code in observation-form page with Sidebar component  
- Replaced duplicate sidebar code in reporting page with Sidebar component
- Removed useState for sidebar collapse state from individual pages
- Added TypeScript interfaces for sidebar props and menu items
- Component supports configurable title, sections, applications, and user profile

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 41`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/cosmos-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>cosmos-world</branchName>-->