### PR TITLE
Update params to Promise type in standards API route

### DIFF
--- a/src/app/api/standards/[id]/route.ts
+++ b/src/app/api/standards/[id]/route.ts
@@ -8,10 +8,11 @@ import {
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const id = parseInt(params.id);
+    const { id: paramId } = await params;
+    const id = parseInt(paramId);
     const standard = await getStandardById(id);
     if (!standard) {
       return NextResponse.json(
@@ -31,10 +32,11 @@ export async function GET(
 
 export async function PUT(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const id = parseInt(params.id);
+    const { id: paramId } = await params;
+    const id = parseInt(paramId);
     const body = await request.json();
     const standard = await updateStandard(id, body);
     return NextResponse.json(standard);
@@ -49,10 +51,11 @@ export async function PUT(
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const id = parseInt(params.id);
+    const { id: paramId } = await params;
+    const id = parseInt(paramId);
     const body = await request.json();
 
     if (body.action === "create_version") {


### PR DESCRIPTION
Updates the params parameter type from `{ id: string }` to `Promise<{ id: string }>` in all three HTTP methods (GET, PUT, POST) of the standards API route.

Changes made:
- Modified params type annotation to use Promise wrapper
- Added await when destructuring params to extract the id
- Updated parameter extraction pattern from `params.id` to `await params` followed by destructuring

This change affects the GET, PUT, and POST handlers in `/src/app/api/standards/[id]/route.ts`.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 46`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/swoosh-works)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>swoosh-works</branchName>-->