### PR TITLE
Refactor dynamic grouping logic with syncActiveRowIds

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -486,6 +486,12 @@ export default function GazeObservationApp() {
         ...prev,
         [id]: 0,
       }));
+
+      // Handle dynamic grouping logic (same as updateQuantity)
+      const newActiveRowIds = new Set(activeRowIds);
+      newActiveRowIds.add(id);
+      setIsDynamicGroupingActive(true);
+      setActiveRowIds(newActiveRowIds);
     }
   };
 

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -801,7 +801,8 @@ export default function GazeObservationApp() {
 
   useEffect(() => {
     calculateTotalSams();
-  }, [rows, submittedQuantities]);
+    syncActiveRowIds();
+  }, [rows, submittedQuantities, syncActiveRowIds]);
 
   useEffect(() => {
     calculatePerformance();

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -453,7 +453,10 @@ export default function GazeObservationApp() {
 
     // Handle dynamic grouping logic
     const newActiveRowIds = new Set(activeRowIds);
-    if (value > 0) {
+    const finalValue = Math.max(0, value);
+    const hasSubmittedQuantity = (submittedQuantities[id] || 0) > 0;
+
+    if (finalValue > 0 || hasSubmittedQuantity) {
       newActiveRowIds.add(id);
       setIsDynamicGroupingActive(true);
     } else {

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -465,22 +465,8 @@ export default function GazeObservationApp() {
       );
       return newRows;
     });
-
-    // Handle dynamic grouping logic
-    const newActiveRowIds = new Set(activeRowIds);
-    const finalValue = Math.max(0, value);
-    const hasSubmittedQuantity = (submittedQuantities[id] || 0) > 0;
-
-    if (finalValue > 0 || hasSubmittedQuantity) {
-      newActiveRowIds.add(id);
-      setIsDynamicGroupingActive(true);
-    } else {
-      newActiveRowIds.delete(id);
-      if (newActiveRowIds.size === 0) {
-        setIsDynamicGroupingActive(false);
-      }
-    }
-    setActiveRowIds(newActiveRowIds);
+    // Note: Dynamic grouping logic will be handled by the syncActiveRowIds function
+    // in the useEffect that triggers when rows change
   };
 
   const updateTempQuantity = (id: number, value: number) => {

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -490,12 +490,8 @@ export default function GazeObservationApp() {
         ...prev,
         [id]: 0,
       }));
-
-      // Handle dynamic grouping logic (same as updateQuantity)
-      const newActiveRowIds = new Set(activeRowIds);
-      newActiveRowIds.add(id);
-      setIsDynamicGroupingActive(true);
-      setActiveRowIds(newActiveRowIds);
+      // Note: Dynamic grouping logic will be handled by the syncActiveRowIds function
+      // in the useEffect that triggers when submittedQuantities change
     }
   };
 

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -171,6 +171,21 @@ export default function GazeObservationApp() {
     },
   };
 
+  // Helper function to sync active row IDs based on quantities
+  const syncActiveRowIds = useCallback(() => {
+    const newActiveRowIds = new Set<number>();
+    rows.forEach((row) => {
+      const hasTickerQuantity = row.quantity > 0;
+      const hasSubmittedQuantity = (submittedQuantities[row.id] || 0) > 0;
+      if (hasTickerQuantity || hasSubmittedQuantity) {
+        newActiveRowIds.add(row.id);
+      }
+    });
+
+    setActiveRowIds(newActiveRowIds);
+    setIsDynamicGroupingActive(newActiveRowIds.size > 0);
+  }, [rows, submittedQuantities]);
+
   // Smart UOM grouping logic
   const getActiveTagsForRows = useCallback(
     (activeIds: Set<number>) => {


### PR DESCRIPTION
Extracts dynamic grouping logic into a reusable helper function and updates the useEffect dependency.

Changes:
- Add syncActiveRowIds helper function to centralize active row ID management
- Remove inline dynamic grouping logic from updateQuantity function
- Remove inline dynamic grouping logic from resetQuantity function
- Add syncActiveRowIds call to existing useEffect hook
- Update useEffect dependencies to include syncActiveRowIds
- Add explanatory comments noting the refactored approach

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 48`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/vortex-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>vortex-haven</branchName>-->