### PR TITLE
Clear highlighted tag group state on standard change

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -407,6 +407,10 @@ export default function GazeObservationApp() {
     setSelectedDepartment("");
     setSelectedArea("");
     setShowStandardDropdown(false);
+    // Clear highlighted tag group when standard is changed
+    setHighlightedTagGroup(new Set());
+    setActiveRowIds(new Set());
+    setIsDynamicGroupingActive(false);
   };
 
   const getSelectedStandardDisplay = () => {

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -918,34 +918,40 @@ export default function GazeObservationApp() {
       return "bg-yellow-200 text-yellow-800 border-yellow-500 shadow-md font-semibold";
     }
 
-    // If there's a highlighted tag group, all other tags should use pastel colors
-    // regardless of their active state
+    // If there's a highlighted tag group, all other tags should use their original pastel colors
+    // but with reduced opacity to create visual distinction
     if (highlightedTagGroup.size > 0) {
-      // Use pastel colors for tag groups
+      // Use pastel colors for tag groups with reduced opacity
       const tagGroupColor = getTagGroupColor(rowTags);
       if (tagGroupColor && rowTags.length > 0) {
-        // Map to appropriate tag background colors (darker than row backgrounds)
+        // Map to appropriate tag background colors (same as original but with reduced opacity)
         const colorMap: Record<string, string> = {
-          "bg-rose-50": "bg-rose-100 text-rose-700 border-rose-300",
-          "bg-blue-50": "bg-blue-100 text-blue-700 border-blue-300",
-          "bg-green-50": "bg-green-100 text-green-700 border-green-300",
-          "bg-purple-50": "bg-purple-100 text-purple-700 border-purple-300",
-          "bg-indigo-50": "bg-indigo-100 text-indigo-700 border-indigo-300",
-          "bg-pink-50": "bg-pink-100 text-pink-700 border-pink-300",
-          "bg-cyan-50": "bg-cyan-100 text-cyan-700 border-cyan-300",
-          "bg-amber-50": "bg-amber-100 text-amber-700 border-amber-300",
-          "bg-emerald-50": "bg-emerald-100 text-emerald-700 border-emerald-300",
-          "bg-violet-50": "bg-violet-100 text-violet-700 border-violet-300",
+          "bg-rose-50": "bg-rose-100 text-rose-600 border-rose-200 opacity-75",
+          "bg-blue-50": "bg-blue-100 text-blue-600 border-blue-200 opacity-75",
+          "bg-green-50":
+            "bg-green-100 text-green-600 border-green-200 opacity-75",
+          "bg-purple-50":
+            "bg-purple-100 text-purple-600 border-purple-200 opacity-75",
+          "bg-indigo-50":
+            "bg-indigo-100 text-indigo-600 border-indigo-200 opacity-75",
+          "bg-pink-50": "bg-pink-100 text-pink-600 border-pink-200 opacity-75",
+          "bg-cyan-50": "bg-cyan-100 text-cyan-600 border-cyan-200 opacity-75",
+          "bg-amber-50":
+            "bg-amber-100 text-amber-600 border-amber-200 opacity-75",
+          "bg-emerald-50":
+            "bg-emerald-100 text-emerald-600 border-emerald-200 opacity-75",
+          "bg-violet-50":
+            "bg-violet-100 text-violet-600 border-violet-200 opacity-75",
         };
         return (
           colorMap[tagGroupColor.bg] ||
-          "bg-gray-100 text-gray-700 border-gray-300"
+          "bg-gray-100 text-gray-600 border-gray-200 opacity-75"
         );
       }
-      return "bg-gray-100 text-gray-700 border-gray-300";
+      return "bg-gray-100 text-gray-600 border-gray-200 opacity-75";
     }
 
-    // When no group is highlighted, use the original logic
+    // When no group is highlighted, use the original logic with proper state handling
     if (isCurrentlyInUse && isActive) {
       return "bg-yellow-200 text-yellow-800 border-yellow-400 shadow-md font-semibold";
     }
@@ -953,10 +959,10 @@ export default function GazeObservationApp() {
       return "bg-green-100 text-green-700 border-green-300";
     }
 
-    // Use pastel colors for tag groups
+    // Use original pastel colors for tag groups (full opacity)
     const tagGroupColor = getTagGroupColor(rowTags);
     if (tagGroupColor && rowTags.length > 0) {
-      // Map to appropriate tag background colors (darker than row backgrounds)
+      // Map to appropriate tag background colors (original colors with full opacity)
       const colorMap: Record<string, string> = {
         "bg-rose-50": "bg-rose-100 text-rose-700 border-rose-300",
         "bg-blue-50": "bg-blue-100 text-blue-700 border-blue-300",

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1419,9 +1419,19 @@ export default function GazeObservationApp() {
                     <h4 className="text-md font-semibold">Operations</h4>
                     <div className="text-sm font-medium">
                       {highlightedTagGroup.size > 0 && (
-                        <div className="flex items-center gap-2 text-yellow-600 mb-1">
-                          🏆 Tag group highlighted - Group moved to top with
-                          gold styling
+                        <div className="flex items-center gap-3 text-yellow-600 mb-1">
+                          <span className="flex items-center gap-2">
+                            🏆 Tag group highlighted - Group moved to top with
+                            gold styling
+                          </span>
+                          <button
+                            onClick={() => {
+                              setHighlightedTagGroup(new Set());
+                            }}
+                            className="px-2 py-1 text-xs bg-yellow-100 text-yellow-700 border border-yellow-300 rounded hover:bg-yellow-200 transition-colors"
+                          >
+                            Clear Highlighting
+                          </button>
                         </div>
                       )}
                       {isDynamicGroupingActive && (


### PR DESCRIPTION
Clear highlighted tag group when standard is changed to prevent stale highlighting state.

Update tag styling to use reduced opacity (75%) for non-highlighted groups when a tag group is highlighted, maintaining original colors but creating better visual distinction.

Add "Clear Highlighting" button to allow users to manually remove tag group highlighting.

Changes:
- Clear highlightedTagGroup, activeRowIds, and isDynamicGroupingActive when standard changes
- Update tag styling to use opacity-75 for non-highlighted groups
- Add Clear Highlighting button with yellow styling
- Update comments to clarify styling behavior

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 51`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/glow-zone)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>glow-zone</branchName>-->