### PR TITLE
Remove delayReason check and update clear button logic

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1496,11 +1496,11 @@ export default function GazeObservationApp() {
                           </span>
                           <button
                             onClick={() => {
-                              // Only clear visual highlighting states, preserve all quantities and data
+                              // Clear all visual highlighting states while preserving quantities
                               setHighlightedTagGroup(new Set());
                               setIsDynamicGroupingActive(false);
-                              // Don't clear activeRowIds immediately, let syncActiveRowIds handle it
-                              // to ensure data preservation
+                              // Force recalculation to ensure UI consistency without affecting quantities
+                              syncActiveRowIds();
                             }}
                             className="px-2 py-1 text-xs bg-yellow-100 text-yellow-700 border border-yellow-300 rounded hover:bg-yellow-200 transition-colors"
                           >

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -605,7 +605,7 @@ export default function GazeObservationApp() {
 
   // Delay timer functionality
   const startDelay = () => {
-    if (!isDelayActive && delayReason) {
+    if (!isDelayActive) {
       setIsDelayActive(true);
       setDelayStartTime(Date.now());
     }


### PR DESCRIPTION
This change makes two updates to the observation form:

1. Removes the `delayReason` condition from the `startDelay` function, allowing delay to start when `!isDelayActive` regardless of delay reason

2. Updates the clear button click handler:
   - Changes comment from "Only clear visual highlighting states, preserve all quantities and data" to "Clear all visual highlighting states while preserving quantities"
   - Replaces comment about not clearing activeRowIds with "Force recalculation to ensure UI consistency without affecting quantities"
   - Adds explicit call to `syncActiveRowIds()` function

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 56`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/orbit-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>orbit-garden</branchName>-->