### PR TITLE
Update dark mode foreground color to darker shade

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,7 +15,7 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
+    --foreground: #333333;
   }
 }
 


### PR DESCRIPTION
Changes the dark mode foreground color from #ededed (light gray) to #333333 (dark gray) in the CSS variables.

This modification affects the --foreground variable within the dark color scheme media query in globals.css.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 63`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/glow-realm)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>glow-realm</branchName>-->