### PR TITLE
Change props to routeProps in StackHandler component

### DIFF
--- a/src/app/handler/[...stack]/page.tsx
+++ b/src/app/handler/[...stack]/page.tsx
@@ -3,5 +3,5 @@
 import { StackHandler } from "@stackframe/stack";
 
 export default function Handler(props: any) {
-  return <StackHandler fullPage {...props} />;
+  return <StackHandler fullPage routeProps={props} />;
 }


### PR DESCRIPTION
Updates the StackHandler component to use `routeProps={props}` instead of spreading `{...props}`.

This changes how props are passed to the StackHandler component in the handler page.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 72`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/mystic-sanctuary)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>mystic-sanctuary</branchName>-->