### PR TITLE
Add root path to public routes in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,7 +5,7 @@ export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Allow public routes
-  const publicRoutes = ["/login", "/handler", "/api/public"];
+  const publicRoutes = ["/", "/login", "/handler", "/api/public"];
   const isPublicRoute = publicRoutes.some((route) =>
     pathname.startsWith(route),
   );


### PR DESCRIPTION
Add "/" to the publicRoutes array in middleware.ts to allow access to the root path without authentication.

Changes:
- Added "/" to the publicRoutes array alongside existing routes "/login", "/handler", and "/api/public"

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 75`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/zenith-nest)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>zenith-nest</branchName>-->