### PR TITLE
Replace CSS with Tailwind classes in Button and Card

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,15 +1,14 @@
-'use client'
+"use client";
 
-import type React from "react"
-import "./Button.css" // Adjust based on your styling approach
+import type React from "react";
 
 interface ButtonProps {
-  text: string
-  variant?: "primary" | "secondary" | "outline" | "ghost"
-  size?: "small" | "medium" | "large"
-  fullWidth?: boolean
-  onClick?: () => void
-  className?: string
+  text: string;
+  variant?: "primary" | "secondary" | "outline" | "ghost";
+  size?: "small" | "medium" | "large";
+  fullWidth?: boolean;
+  onClick?: () => void;
+  className?: string;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -20,20 +19,37 @@ export const Button: React.FC<ButtonProps> = ({
   onClick,
   className = "",
 }) => {
-  const baseClass = "button"
-  const variantClass = `${baseClass}--${variant}`
-  const sizeClass = `${baseClass}--${size}`
-  const widthClass = fullWidth ? `${baseClass}--full-width` : ""
+  const baseClasses =
+    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background";
+
+  const variantClasses = {
+    primary: "bg-primary text-primary-foreground hover:bg-primary/90",
+    secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+    outline:
+      "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+    ghost: "hover:bg-accent hover:text-accent-foreground",
+  };
+
+  const sizeClasses = {
+    small: "h-9 px-3 text-sm",
+    medium: "h-10 py-2 px-4",
+    large: "h-11 px-8",
+  };
+
+  const widthClass = fullWidth ? "w-full" : "";
 
   const handleClick = () => {
     if (onClick) {
-      onClick()
+      onClick();
     }
-  }
+  };
 
   return (
-    <button className={`${baseClass} ${variantClass} ${sizeClass} ${widthClass} ${className}`} onClick={handleClick}>
+    <button
+      className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${widthClass} ${className}`}
+      onClick={handleClick}
+    >
       {text}
     </button>
-  )
-}
+  );
+};

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,9 +1,8 @@
-'use client';
+"use client";
 
-import type { ReactNode } from 'react';
-import Image from 'next/image';
-import { Button } from './Button';
-import './Card.css'; // keep your existing styles
+import type { ReactNode } from "react";
+import Image from "next/image";
+import { Button } from "./Button";
 
 interface CardProps {
   title: string;
@@ -13,43 +12,55 @@ interface CardProps {
   buttonLink?: string;
   elevation?: number;
   className?: string;
-  children?: ReactNode;           // optional slot if you need extra markup
+  children?: ReactNode;
 }
 
 export const Card = ({
   title,
   description,
-  image = 'https://placehold.co/600x400',
-  buttonText = 'Learn More',
-  buttonLink = '#',
+  image = "https://placehold.co/600x400",
+  buttonText = "Learn More",
+  buttonLink = "#",
   elevation = 1,
-  className = '',
+  className = "",
   children,
 }: CardProps) => {
+  const elevationClasses = {
+    0: "",
+    1: "shadow-sm",
+    2: "shadow-md",
+    3: "shadow-lg",
+    4: "shadow-xl",
+    5: "shadow-2xl",
+  };
+
   return (
-    <article className={`card card--elevation-${elevation} ${className}`}>
+    <article
+      className={`rounded-lg border bg-card text-card-foreground ${elevationClasses[elevation as keyof typeof elevationClasses] || elevationClasses[1]} ${className}`}
+    >
       {image && (
-        <div className="card__image-container">
-          {/* next/image replaces the <img> tag */}
+        <div className="overflow-hidden rounded-t-lg">
           <Image
             src={image}
             alt={title}
             width={600}
             height={400}
-            className="card__image"
+            className="h-48 w-full object-cover transition-transform hover:scale-105"
             priority
           />
         </div>
       )}
 
-      <div className="card__content">
-        <h3 className="card__title">{title}</h3>
-        <p className="card__description">{description}</p>
+      <div className="p-6">
+        <h3 className="text-2xl font-semibold leading-none tracking-tight mb-2">
+          {title}
+        </h3>
+        <p className="text-sm text-muted-foreground mb-4">{description}</p>
 
-        {children /* optional extra JSX */}
+        {children}
 
         {buttonText && (
-          <a href={buttonLink} className="card__button-link">
+          <a href={buttonLink} className="inline-block">
             <Button text={buttonText} variant="primary" size="medium" />
           </a>
         )}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,15 +1,14 @@
-'use client'
+"use client";
 
-import type React from "react"
-import "./Button.css" // Adjust based on your styling approach
+import type React from "react";
 
 interface ButtonProps {
-  text: string
-  variant?: "primary" | "secondary" | "outline" | "ghost"
-  size?: "small" | "medium" | "large"
-  fullWidth?: boolean
-  onClick?: () => void
-  className?: string
+  text: string;
+  variant?: "primary" | "secondary" | "outline" | "ghost";
+  size?: "small" | "medium" | "large";
+  fullWidth?: boolean;
+  onClick?: () => void;
+  className?: string;
 }
 
 export const Button: React.FC<ButtonProps> = ({
@@ -20,20 +19,37 @@ export const Button: React.FC<ButtonProps> = ({
   onClick,
   className = "",
 }) => {
-  const baseClass = "button"
-  const variantClass = `${baseClass}--${variant}`
-  const sizeClass = `${baseClass}--${size}`
-  const widthClass = fullWidth ? `${baseClass}--full-width` : ""
+  const baseClasses =
+    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background";
+
+  const variantClasses = {
+    primary: "bg-primary text-primary-foreground hover:bg-primary/90",
+    secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+    outline:
+      "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+    ghost: "hover:bg-accent hover:text-accent-foreground",
+  };
+
+  const sizeClasses = {
+    small: "h-9 px-3 text-sm",
+    medium: "h-10 py-2 px-4",
+    large: "h-11 px-8",
+  };
+
+  const widthClass = fullWidth ? "w-full" : "";
 
   const handleClick = () => {
     if (onClick) {
-      onClick()
+      onClick();
     }
-  }
+  };
 
   return (
-    <button className={`${baseClass} ${variantClass} ${sizeClass} ${widthClass} ${className}`} onClick={handleClick}>
+    <button
+      className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${widthClass} ${className}`}
+      onClick={handleClick}
+    >
       {text}
     </button>
-  )
-}
+  );
+};

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,9 +1,8 @@
-'use client';
+"use client";
 
-import type { ReactNode } from 'react';
-import Image from 'next/image';
-import { Button } from './Button';
-import './Card.css';
+import type { ReactNode } from "react";
+import Image from "next/image";
+import { Button } from "./Button";
 
 export interface CardProps {
   title: string;
@@ -20,39 +19,53 @@ export interface CardProps {
 export const Card = ({
   title,
   description,
-  image = 'https://placehold.co/600x400',
-  buttonText = 'Learn More',
-  buttonLink = '#',
+  image = "https://placehold.co/600x400",
+  buttonText = "Learn More",
+  buttonLink = "#",
   elevation = 1,
-  className = '',
+  className = "",
   children,
-}: CardProps) => (
-  <article className={`card card--elevation-${elevation} ${className}`}>
-    {image && (
-      <div className="card__image-container">
-        {/* next/image satisfies @next/next/no-img-element */}
-        <Image
-          src={image}
-          alt={title}
-          width={600}
-          height={400}
-          className="card__image"
-          priority
-        />
-      </div>
-    )}
+}: CardProps) => {
+  const elevationClasses = {
+    0: "",
+    1: "shadow-sm",
+    2: "shadow-md",
+    3: "shadow-lg",
+    4: "shadow-xl",
+    5: "shadow-2xl",
+  };
 
-    <div className="card__content">
-      <h3 className="card__title">{title}</h3>
-      <p className="card__description">{description}</p>
-
-      {children /* optional nested Builder content */}
-
-      {buttonText && (
-        <a href={buttonLink} className="card__button-link">
-          <Button text={buttonText} variant="primary" size="medium" />
-        </a>
+  return (
+    <article
+      className={`rounded-lg border bg-card text-card-foreground ${elevationClasses[elevation as keyof typeof elevationClasses] || elevationClasses[1]} ${className}`}
+    >
+      {image && (
+        <div className="overflow-hidden rounded-t-lg">
+          <Image
+            src={image}
+            alt={title}
+            width={600}
+            height={400}
+            className="h-48 w-full object-cover transition-transform hover:scale-105"
+            priority
+          />
+        </div>
       )}
-    </div>
-  </article>
-);
+
+      <div className="p-6">
+        <h3 className="text-2xl font-semibold leading-none tracking-tight mb-2">
+          {title}
+        </h3>
+        <p className="text-sm text-muted-foreground mb-4">{description}</p>
+
+        {children}
+
+        {buttonText && (
+          <a href={buttonLink} className="inline-block">
+            <Button text={buttonText} variant="primary" size="medium" />
+          </a>
+        )}
+      </div>
+    </article>
+  );
+};


### PR DESCRIPTION
Replace CSS imports and class-based styling with Tailwind utility classes in Button and Card components.

Changes made:
- Remove CSS file imports from Button.tsx and Card.tsx
- Replace BEM-style CSS classes with Tailwind utility classes
- Convert string-based class concatenation to object-based class mapping
- Add Tailwind classes for styling variants, sizes, and elevation levels
- Update quote style from single to double quotes for consistency
- Add semicolons to all statements for consistent code formatting

The components maintain the same visual appearance and functionality while using Tailwind's utility-first approach.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 98`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/neon-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>neon-space</branchName>-->