### PR TITLE
Add lucide-react dependency and transpile config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,8 +10,12 @@ const nextConfig = {
     unoptimized: true,
   },
 
-  // Transpile Stack Auth packages to handle ES modules properly
-  transpilePackages: ["@stackframe/stack", "@stackframe/stack-sc"],
+  // Transpile Stack Auth packages and lucide-react to handle ES modules properly
+  transpilePackages: [
+    "@stackframe/stack",
+    "@stackframe/stack-sc",
+    "lucide-react",
+  ],
 
   // External packages for server components
   serverExternalPackages: ["@prisma/client", "prisma"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@stackframe/stack": "^2.8.17",
         "@stackframe/stack-sc": "^2.8.17",
         "glob": "^10.4.5",
+        "lucide-react": "^0.525.0",
         "next": "^15.3.5",
         "node-fetch": "^2.7.0",
         "prisma": "^6.11.1",
@@ -4549,6 +4550,15 @@
         "yup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@stackframe/stack-ui/node_modules/lucide-react": {
+      "version": "0.508.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.508.0.tgz",
+      "integrity": "sha512-gcP16PnexqtOFrTtv98kVsGzTfnbPekzZiQfByi2S89xfk7E/4uKE1USZqccIp58v42LqkO7MuwpCqshwSrJCg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@stackframe/stack/node_modules/cookie": {
@@ -9704,9 +9714,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.508.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.508.0.tgz",
-      "integrity": "sha512-gcP16PnexqtOFrTtv98kVsGzTfnbPekzZiQfByi2S89xfk7E/4uKE1USZqccIp58v42LqkO7MuwpCqshwSrJCg==",
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@stackframe/stack": "^2.8.17",
     "@stackframe/stack-sc": "^2.8.17",
     "glob": "^10.4.5",
+    "lucide-react": "^0.525.0",
     "next": "^15.3.5",
     "node-fetch": "^2.7.0",
     "prisma": "^6.11.1",


### PR DESCRIPTION
Add lucide-react package as a dependency and update Next.js configuration to transpile it.

Changes:
- Add lucide-react ^0.525.0 to package.json dependencies
- Update transpilePackages in next.config.js to include "lucide-react"
- Update comment to reflect the addition of lucide-react transpilation
- Update package-lock.json with new dependency resolution

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 104`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/nova-verse)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>nova-verse</branchName>-->