### PR TITLE
Remove auth loading state and fix SSR environment checks

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,31 +1,9 @@
-"use client";
-
-import { Suspense, useEffect, useState } from "react";
-import { useUser } from "@stackframe/stack";
+import { Suspense } from "react";
 import DashboardContent from "../../components/DashboardContent";
 import { Banner } from "../../components/ui/Banner";
 import { Sidebar } from "../../components/Sidebar";
 
 export default function DashboardPage() {
-  const user = useUser();
-  const [showDashboard, setShowDashboard] = useState(false);
-
-  useEffect(() => {
-    // Allow dashboard to show regardless of auth status for demo purposes
-    setShowDashboard(true);
-  }, []);
-
-  if (!showDashboard) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-100">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading dashboard...</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="font-poppins text-black bg-gray-100 min-h-screen overflow-x-hidden">
       <Banner

--- a/src/app/status/page.tsx
+++ b/src/app/status/page.tsx
@@ -26,16 +26,25 @@ export default function StatusPage() {
   }, []);
 
   const checkSystemStatus = async () => {
-    // Check Builder.io configuration
-    const builderKey = process.env.NEXT_PUBLIC_BUILDER_API_KEY;
+    // Check Builder.io configuration (client-side only)
+    const builderKey =
+      typeof window !== "undefined"
+        ? process.env.NEXT_PUBLIC_BUILDER_API_KEY
+        : null;
     const builderStatus =
       builderKey && builderKey !== "YOUR_BUILDER_API_KEY_HERE"
         ? "configured"
         : "missing";
 
-    // Check Stack Auth configuration
-    const stackProjectId = process.env.NEXT_PUBLIC_STACK_PROJECT_ID;
-    const stackClientKey = process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY;
+    // Check Stack Auth configuration (client-side only)
+    const stackProjectId =
+      typeof window !== "undefined"
+        ? process.env.NEXT_PUBLIC_STACK_PROJECT_ID
+        : null;
+    const stackClientKey =
+      typeof window !== "undefined"
+        ? process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY
+        : null;
     const stackStatus =
       stackProjectId && stackClientKey ? "configured" : "missing";
 
@@ -58,7 +67,9 @@ export default function StatusPage() {
       builderIO: builderStatus,
       stackAuth: stackStatus,
       environment:
-        process.env.NODE_ENV === "production" ? "production" : "development",
+        typeof window !== "undefined" && process.env.NODE_ENV === "production"
+          ? "production"
+          : "development",
     });
 
     setDbStats(stats);


### PR DESCRIPTION
This pull request makes two main changes:

**Dashboard Page:**
- Removes "use client" directive and converts to server component
- Removes user authentication state management and loading spinner
- Removes useEffect hook that was showing dashboard regardless of auth status
- Simplifies component to directly render dashboard content

**Status Page:**
- Adds client-side checks using `typeof window !== "undefined"` before accessing environment variables
- Wraps Builder.io API key, Stack Auth project ID, and client key checks with window checks
- Updates environment detection to only check NODE_ENV on client-side
- Prevents server-side rendering errors when accessing browser-only environment variables

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 107`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/curry-home)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-curry-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>curry-home</branchName>-->