### PR TITLE
Add allowedDevOrigins config for cross-origin requests

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,12 @@ const nextConfig = {
 
   // Additional configuration for Vercel
   output: process.env.NODE_ENV === "production" ? "standalone" : undefined,
+
+  // Fix cross-origin requests in development
+  allowedDevOrigins: [
+    "446e49d2fb5c4fe1b3830aa578d409fe-3c6932f6df3a4e8d995d8b1e6.fly.dev",
+    "*.fly.dev",
+  ],
 };
 
 // If you want the Builder DevTools overlay in dev, wrap once:


### PR DESCRIPTION
Add allowedDevOrigins configuration to next.config.js to fix cross-origin requests in development.

The configuration includes:
- Specific fly.dev subdomain: 446e49d2fb5c4fe1b3830aa578d409fe-3c6932f6df3a4e8d995d8b1e6.fly.dev
- Wildcard pattern for all fly.dev subdomains: *.fly.dev

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 110`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/orbit-sanctuary)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-orbit-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>orbit-sanctuary</branchName>-->