### PR TITLE
Remove middleware and simplify database schema

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,9 +1,0 @@
-import { NextRequest, NextResponse } from "next/server";
-
-export function middleware(request: NextRequest) {
-  return NextResponse.next();
-}
-
-export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
-};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,64 +8,17 @@ datasource db {
 }
 
 model User {
-  id             String        @id @default(cuid())
-  employeeId     String        @unique
-  employeeNumber String?
-  name           String
-  email          String?
-  department     String?
-  role           String?
-  roleId         String?
-  isActive       Boolean       @default(true)
-  lastSyncAt     DateTime?
-  externalSource String?       // "active_directory", "sailpoint", "manual"
-  createdAt      DateTime      @default(now())
-  updatedAt      DateTime      @updatedAt
-  observations   Observation[]
-  userRole       Role?         @relation(fields: [roleId], references: [id])
+  id           String        @id @default(cuid())
+  employeeId   String        @unique
+  name         String
+  email        String?
+  department   String?
+  role         String?
+  createdAt    DateTime      @default(now())
+  updatedAt    DateTime      @updatedAt
+  observations Observation[]
 
   @@map("users")
-}
-
-model Role {
-  id          String       @id @default(cuid())
-  name        String       @unique
-  description String?
-  isActive    Boolean      @default(true)
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  users       User[]
-  permissions RolePermission[]
-
-  @@map("roles")
-}
-
-model Permission {
-  id          String       @id @default(cuid())
-  name        String       @unique
-  description String?
-  module      String       // e.g., "users", "observations", "standards"
-  action      String       // e.g., "create", "read", "update", "delete"
-  isActive    Boolean      @default(true)
-  createdAt   DateTime     @default(now())
-  updatedAt   DateTime     @updatedAt
-  roles       RolePermission[]
-
-  @@map("permissions")
-}
-
-model RolePermission {
-  id           String     @id @default(cuid())
-  roleId       String
-  permissionId String
-  granted      Boolean    @default(true)
-  createdAt    DateTime   @default(now())
-  updatedAt    DateTime   @updatedAt
-  role         Role       @relation(fields: [roleId], references: [id], onDelete: Cascade)
-  permission   Permission @relation(fields: [permissionId], references: [id], onDelete: Cascade)
-
-  @@unique([roleId, permissionId])
-  @@map("role_permissions")
 }
 
 model Organization {
@@ -132,15 +85,8 @@ model Standard {
   bestPractices        String[]      @default([])
   isActive             Boolean       @default(true)
   processOpportunities String[]      @default([])
-  version              Int           @default(1)
-  baseStandardId       Int?
-  isCurrentVersion     Boolean       @default(true)
-  versionNotes         String?
-  createdBy            String?
   observations         Observation[]
   area                 Area          @relation(fields: [areaId], references: [id], onDelete: Cascade)
-  baseStandard         Standard?     @relation("StandardVersions", fields: [baseStandardId], references: [id])
-  versions             Standard[]    @relation("StandardVersions")
   department           Department    @relation(fields: [departmentId], references: [id], onDelete: Cascade)
   facility             Facility      @relation(fields: [facilityId], references: [id], onDelete: Cascade)
   uomEntries           UomEntry[]
@@ -191,30 +137,6 @@ model Observation {
   user                    User              @relation(fields: [userId], references: [id])
 
   @@map("observations")
-}
-
-model DelayReason {
-  id          String   @id @default(cuid())
-  name        String   @unique
-  description String?
-  isActive    Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
-
-  @@map("delay_reasons")
-}
-
-model ObservationReason {
-  id               String   @id @default(cuid())
-  name             String   @unique
-  description      String?
-  externalApiUrl   String?
-  apiConfiguration Json?
-  isActive         Boolean  @default(true)
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
-
-  @@map("observation_reasons")
 }
 
 model ObservationData {


### PR DESCRIPTION
This pull request removes unused middleware and simplifies the database schema by removing several models and fields.

Changes made:
- Deleted middleware.ts file completely
- Removed Role, Permission, RolePermission, DelayReason, and ObservationReason models from Prisma schema
- Simplified User model by removing employeeNumber, roleId, isActive, lastSyncAt, externalSource fields and userRole relation
- Removed versioning fields from Standard model: version, baseStandardId, isCurrentVersion, versionNotes, createdBy and related self-referencing relation

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 116`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/mystic-zone)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-mystic-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>mystic-zone</branchName>-->