### PR TITLE
Add notes field to CSV standard data structure

### DIFF
--- a/lib/csv-utils.ts
+++ b/lib/csv-utils.ts
@@ -7,6 +7,7 @@ export interface StandardCsvRow {
   departmentName: string;
   areaName: string;
   standardName: string;
+  notes: string;
   // UOM entries (up to 75)
   [key: `uom${number}_name`]: string;
   [key: `uom${number}_description`]: string;
@@ -33,6 +34,7 @@ export interface ParsedStandardData {
   departmentName: string;
   areaName: string;
   standardName: string;
+  notes: string;
   uomEntries: Array<{
     uom: string;
     description: string;
@@ -60,6 +62,7 @@ export function generateCsvTemplate(): string {
     "departmentName",
     "areaName",
     "standardName",
+    "notes",
   ];
 
   // Add UOM headers (up to 75)
@@ -90,6 +93,7 @@ export function generateCsvTemplate(): string {
     "Production",
     "Assembly Line A",
     "Widget Assembly Standard",
+    "Additional notes about this standard",
   ];
 
   // Add sample UOM data for first few entries
@@ -168,6 +172,7 @@ export function validateStandardRow(
     "departmentName",
     "areaName",
     "standardName",
+    "notes",
   ];
 
   requiredFields.forEach((field) => {
@@ -314,6 +319,7 @@ export function transformRowToStandardData(
     departmentName: row.departmentName.trim(),
     areaName: row.areaName.trim(),
     standardName: row.standardName.trim(),
+    notes: row.notes?.trim() || "",
     uomEntries,
     bestPractices,
     processOpportunities,

--- a/src/app/api/standards/upload/route.ts
+++ b/src/app/api/standards/upload/route.ts
@@ -222,6 +222,7 @@ async function createStandardFromData(data: ParsedStandardData) {
         facilityId: facility.id,
         departmentId: department.id,
         areaId: area.id,
+        notes: data.notes,
         bestPractices: data.bestPractices,
         processOpportunities: data.processOpportunities,
         uomEntries: {


### PR DESCRIPTION
Add notes field to the CSV standard data structure and processing pipeline.

Changes include:
- Add notes field to StandardCsvRow interface
- Add notes field to ParsedStandardData interface  
- Include notes in CSV template headers and sample data
- Add notes validation in validateStandardRow function
- Transform notes field in transformRowToStandardData function
- Pass notes field to standard creation in upload route

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 122`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/echo-lab)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-echo-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>echo-lab</branchName>-->