### PR TITLE
Add DelayReason and ObservationReason models to schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -219,6 +219,30 @@ model UserRole {
   role           Role          @relation(fields: [roleId], references: [id], onDelete: Cascade)
   organization   Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
-  @@unique([userId, roleId, organizationId])
+    @@unique([userId, roleId, organizationId])
   @@map("user_roles")
+}
+
+model DelayReason {
+  id          String   @id @default(cuid())
+  name        String   @unique
+  description String?
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@map("delay_reasons")
+}
+
+model ObservationReason {
+  id               String   @id @default(cuid())
+  name             String   @unique
+  description      String?
+  isActive         Boolean  @default(true)
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+  apiConfiguration Json?
+  externalApiUrl   String?
+
+  @@map("observation_reasons")
 }


### PR DESCRIPTION
This change adds two new models to the Prisma schema:

**DelayReason model:**
- Primary key: id (cuid)
- Unique name field
- Optional description
- isActive boolean (defaults to true)
- Standard timestamps (createdAt, updatedAt)
- Maps to "delay_reasons" table

**ObservationReason model:**
- Primary key: id (cuid)
- Unique name field
- Optional description
- isActive boolean (defaults to true)
- Standard timestamps (createdAt, updatedAt)
- Optional apiConfiguration (Json field)
- Optional externalApiUrl string
- Maps to "observation_reasons" table

Also includes minor indentation fix in the UserRole model's unique constraint.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 125`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/zen-nest)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-zen-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>zen-nest</branchName>-->