### PR TITLE
Update user-role relationship from one-to-one to many-to-many

### DIFF
--- a/lib/db-operations.ts
+++ b/lib/db-operations.ts
@@ -552,14 +552,14 @@ export async function getRoles() {
   return prisma.role.findMany({
     orderBy: { name: "asc" },
     include: {
-      permissions: {
+      rolePermissions: {
         include: {
           permission: true,
         },
       },
       _count: {
         select: {
-          users: true,
+          userRoles: true,
         },
       },
     },
@@ -570,14 +570,14 @@ export async function getRoleById(id: string) {
   return prisma.role.findUnique({
     where: { id },
     include: {
-      permissions: {
+      rolePermissions: {
         include: {
           permission: true,
         },
       },
       _count: {
         select: {
-          users: true,
+          userRoles: true,
         },
       },
     },
@@ -594,24 +594,23 @@ export async function createRole(data: {
   return prisma.role.create({
     data: {
       ...roleData,
-      permissions: permissionIds
+      rolePermissions: permissionIds
         ? {
             create: permissionIds.map((permissionId) => ({
               permissionId,
-              granted: true,
             })),
           }
         : undefined,
     },
     include: {
-      permissions: {
+      rolePermissions: {
         include: {
           permission: true,
         },
       },
       _count: {
         select: {
-          users: true,
+          userRoles: true,
         },
       },
     },
@@ -659,14 +658,14 @@ export async function updateRole(
     return tx.role.findUnique({
       where: { id },
       include: {
-        permissions: {
+        rolePermissions: {
           include: {
             permission: true,
           },
         },
         _count: {
           select: {
-            users: true,
+            userRoles: true,
           },
         },
       },

--- a/lib/db-operations.ts
+++ b/lib/db-operations.ts
@@ -442,7 +442,11 @@ export async function createUser(data: {
   return prisma.user.create({
     data,
     include: {
-      userRole: true,
+      userRoles: {
+        include: {
+          role: true,
+        },
+      },
     },
   });
 }
@@ -466,7 +470,11 @@ export async function updateUser(
     where: { id },
     data,
     include: {
-      userRole: true,
+      userRoles: {
+        include: {
+          role: true,
+        },
+      },
     },
   });
 }
@@ -481,7 +489,11 @@ export async function getUserByEmployeeId(employeeId: string) {
   return prisma.user.findUnique({
     where: { employeeId },
     include: {
-      userRole: true,
+      userRoles: {
+        include: {
+          role: true,
+        },
+      },
     },
   });
 }
@@ -490,7 +502,11 @@ export async function getUserById(id: string) {
   return prisma.user.findUnique({
     where: { id },
     include: {
-      userRole: true,
+      userRoles: {
+        include: {
+          role: true,
+        },
+      },
     },
   });
 }
@@ -499,7 +515,11 @@ export async function getUsers() {
   return prisma.user.findMany({
     orderBy: { name: "asc" },
     include: {
-      userRole: true,
+      userRoles: {
+        include: {
+          role: true,
+        },
+      },
     },
   });
 }

--- a/lib/db-operations.ts
+++ b/lib/db-operations.ts
@@ -682,8 +682,7 @@ export async function deleteRole(id: string) {
 // Permission operations
 export async function getPermissions() {
   return prisma.permission.findMany({
-    where: { isActive: true },
-    orderBy: [{ module: "asc" }, { action: "asc" }],
+    orderBy: [{ resource: "asc" }, { action: "asc" }],
   });
 }
 

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -40,7 +40,9 @@ export default function AdminPage() {
           totalUsers: users.length,
           activeSessions: users.filter((user: any) => user.isActive).length,
           adminUsers: users.filter((user: any) =>
-            user.userRole?.name?.toLowerCase().includes("admin"),
+            user.userRoles?.some((userRole: any) =>
+              userRole.role?.name?.toLowerCase().includes("admin"),
+            ),
           ).length,
         });
       }
@@ -85,7 +87,9 @@ function AdminContent() {
           totalUsers: users.length,
           activeSessions: users.filter((user: any) => user.isActive).length,
           adminUsers: users.filter((user: any) =>
-            user.userRole?.name?.toLowerCase().includes("admin"),
+            user.userRoles?.some((userRole: any) =>
+              userRole.role?.name?.toLowerCase().includes("admin"),
+            ),
           ).length,
         });
       }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -23,11 +23,14 @@ interface User {
   lastSyncAt?: string;
   createdAt: string;
   updatedAt: string;
-  userRole?: {
-    id: string;
-    name: string;
-    description?: string;
-  };
+  userRoles?: {
+    id: number;
+    role: {
+      id: number;
+      name: string;
+      description?: string;
+    };
+  }[];
 }
 
 export default function UsersAdminPage() {
@@ -365,7 +368,9 @@ export default function UsersAdminPage() {
                             {user.department || "—"}
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-500">
-                            {user.userRole?.name || user.role || "—"}
+                            {user.userRoles?.[0]?.role?.name ||
+                              user.role ||
+                              "—"}
                           </td>
                           <td className="px-4 py-3 text-sm">
                             <span


### PR DESCRIPTION
Updates the database operations and UI components to support a many-to-many relationship between users and roles.

Changes include:
- Replace `userRole` with `userRoles` array in all user database operations
- Update role operations to use `rolePermissions` instead of `permissions`
- Remove `granted` field from role permission creation
- Update permission queries to use `resource` field instead of `module`
- Remove `isActive` filter from permission queries
- Update admin page logic to handle multiple user roles
- Modify user interface to display first role from userRoles array
- Update TypeScript interfaces to reflect new relationship structure

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 133`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/mystic-den)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-mystic-den.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>mystic-den</branchName>-->