### PR TITLE
Add ObservationReason model and simplify API responses

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -233,3 +233,16 @@ model DelayReason {
 
   @@map("delay_reasons")
 }
+
+model ObservationReason {
+  id               String  @id @default(cuid())
+  name             String  @unique
+  description      String?
+  isActive         Boolean @default(true)
+  externalApiUrl   String?
+  apiConfiguration Json?
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@map("observation_reasons")
+}

--- a/src/app/api/standards/route.ts
+++ b/src/app/api/standards/route.ts
@@ -62,10 +62,7 @@ export async function POST(request: NextRequest) {
     // Create standard with tenant validation
     const standard = await createStandard(body, tenantContext);
 
-    return NextResponse.json({
-      data: standard,
-      message: "Standard created successfully",
-    });
+    return NextResponse.json(standard);
   } catch (error: any) {
     console.error("Error creating standard:", error);
 

--- a/src/app/api/standards/route.ts
+++ b/src/app/api/standards/route.ts
@@ -10,14 +10,7 @@ export async function GET() {
     );
     const standards = await getStandardsDirect();
 
-    return NextResponse.json({
-      data: standards,
-      meta: {
-        organizationId: null,
-        isSystemSuperuser: false,
-        count: standards.length,
-      },
-    });
+    return NextResponse.json(standards);
   } catch (error: any) {
     console.error("Error fetching standards:", error);
 


### PR DESCRIPTION
This pull request makes two main changes:

1. **Add ObservationReason model to Prisma schema**
   - Creates new ObservationReason model with fields: id, name, description, isActive, externalApiUrl, apiConfiguration, createdAt, updatedAt
   - Maps to "observation_reasons" table
   - Includes unique constraint on name field

2. **Simplify standards API response format**
   - Remove wrapper object with data/meta structure from GET endpoint
   - Remove wrapper object with data/message structure from POST endpoint
   - Return data directly instead of nested in response objects

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 134`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/neon-forge)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-neon-forge.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>neon-forge</branchName>-->