### PR TITLE
Add limit parameter and update ID types to string

### DIFF
--- a/lib/db-operations.ts
+++ b/lib/db-operations.ts
@@ -834,7 +834,7 @@ export async function createObservation(data: {
   });
 }
 
-export async function getObservationsByUser(userId: string) {
+export async function getObservationsByUser(userId: string, limit?: number) {
   return prisma.observation.findMany({
     where: { userId },
     include: {
@@ -853,6 +853,7 @@ export async function getObservationsByUser(userId: string) {
       observationData: true,
     },
     orderBy: { createdAt: "desc" },
+    take: limit,
   });
 }
 

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -5,21 +5,21 @@ import { Banner } from "@/components/ui/Banner";
 import { Sidebar } from "@/components/Sidebar";
 
 interface Permission {
-  id: number;
+  id: string;
   name: string;
   description?: string;
-  resource: string;
+  module: string;
   action: string;
 }
 
 interface RolePermission {
-  id: number;
-  permissionId: number;
+  id: string;
+  permissionId: string;
   permission: Permission;
 }
 
 interface Role {
-  id: number;
+  id: string;
   name: string;
   description?: string;
   isActive?: boolean;
@@ -27,7 +27,7 @@ interface Role {
   updatedAt: string;
   rolePermissions: RolePermission[];
   _count?: {
-    userRoles: number;
+    user_roles: number;
   };
 }
 
@@ -178,27 +178,24 @@ export default function RolesAdminPage() {
 
   const openEditModal = (role: Role) => {
     setEditingRole(role);
-    setSelectedPermissions(
-      role.rolePermissions.map((rp) => rp.permissionId.toString()),
-    );
+    setSelectedPermissions(role.rolePermissions.map((rp) => rp.permissionId));
   };
 
-  const togglePermission = (permissionId: number) => {
-    const permissionIdStr = permissionId.toString();
+  const togglePermission = (permissionId: string) => {
     setSelectedPermissions((prev) =>
-      prev.includes(permissionIdStr)
-        ? prev.filter((id) => id !== permissionIdStr)
-        : [...prev, permissionIdStr],
+      prev.includes(permissionId)
+        ? prev.filter((id) => id !== permissionId)
+        : [...prev, permissionId],
     );
   };
 
-  const groupPermissionsByResource = (permissions: Permission[]) => {
+  const groupPermissionsByModule = (permissions: Permission[]) => {
     return permissions.reduce(
       (acc, permission) => {
-        if (!acc[permission.resource]) {
-          acc[permission.resource] = [];
+        if (!acc[permission.module]) {
+          acc[permission.module] = [];
         }
-        acc[permission.resource].push(permission);
+        acc[permission.module].push(permission);
         return acc;
       },
       {} as Record<string, Permission[]>,
@@ -206,7 +203,7 @@ export default function RolesAdminPage() {
   };
 
   const activeRoles = roles.filter((role) => role.isActive !== false);
-  const groupedPermissions = groupPermissionsByResource(permissions);
+  const groupedPermissions = groupPermissionsByModule(permissions);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -328,16 +325,16 @@ export default function RolesAdminPage() {
                 </label>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {Object.entries(groupedPermissions).map(
-                    ([resource, resourcePermissions]) => (
+                    ([module, modulePermissions]) => (
                       <div
-                        key={resource}
+                        key={module}
                         className="border border-gray-200 rounded-lg p-3"
                       >
                         <h4 className="font-medium text-gray-800 mb-2 capitalize">
-                          {resource}
+                          {module}
                         </h4>
                         <div className="space-y-2">
-                          {resourcePermissions.map((permission) => (
+                          {modulePermissions.map((permission) => (
                             <label
                               key={permission.id}
                               className="flex items-center"
@@ -345,7 +342,7 @@ export default function RolesAdminPage() {
                               <input
                                 type="checkbox"
                                 checked={selectedPermissions.includes(
-                                  permission.id.toString(),
+                                  permission.id,
                                 )}
                                 onChange={() => togglePermission(permission.id)}
                                 className="mr-2"
@@ -423,16 +420,16 @@ export default function RolesAdminPage() {
                     </label>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                       {Object.entries(groupedPermissions).map(
-                        ([resource, resourcePermissions]) => (
+                        ([module, modulePermissions]) => (
                           <div
-                            key={resource}
+                            key={module}
                             className="border border-gray-200 rounded-lg p-3"
                           >
                             <h4 className="font-medium text-gray-800 mb-2 capitalize">
-                              {resource}
+                              {module}
                             </h4>
                             <div className="space-y-2">
-                              {resourcePermissions.map((permission) => (
+                              {modulePermissions.map((permission) => (
                                 <label
                                   key={permission.id}
                                   className="flex items-center"
@@ -440,7 +437,7 @@ export default function RolesAdminPage() {
                                   <input
                                     type="checkbox"
                                     checked={selectedPermissions.includes(
-                                      permission.id.toString(),
+                                      permission.id,
                                     )}
                                     onChange={() =>
                                       togglePermission(permission.id)
@@ -541,7 +538,7 @@ export default function RolesAdminPage() {
                             {role.rolePermissions.length} permissions
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-500">
-                            {role._count?.userRoles || 0} users
+                            {role._count?.user_roles || 0} users
                           </td>
                           <td className="px-4 py-3 text-sm text-gray-500">
                             {new Date(role.createdAt).toLocaleDateString()}

--- a/src/app/api/observations/route.ts
+++ b/src/app/api/observations/route.ts
@@ -1,10 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createObservation, getRecentObservations } from "@/lib/db-operations";
+import {
+  createObservation,
+  getRecentObservations,
+  getObservationsByUser,
+} from "@/lib/db-operations";
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
-    const observations = await getRecentObservations(50);
-    return NextResponse.json(observations);
+    const { searchParams } = new URL(request.url);
+    const userId = searchParams.get("userId");
+    const limit = parseInt(searchParams.get("limit") || "50");
+
+    if (userId) {
+      const observations = await getObservationsByUser(userId, limit);
+      return NextResponse.json(observations);
+    } else {
+      const observations = await getRecentObservations(limit);
+      return NextResponse.json(observations);
+    }
   } catch (error) {
     console.error("Error fetching observations:", error);
     return NextResponse.json(

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -142,6 +142,9 @@ export default function GazeObservationApp() {
   const [delayReasons, setDelayReasons] = useState<
     { id: string; name: string; description?: string }[]
   >([]);
+  const [observationReasons, setObservationReasons] = useState<
+    { id: string; name: string; description?: string }[]
+  >([]);
 
   // Best practices and process adherence
   const [bestPracticesChecked, setBestPracticesChecked] = useState<string[]>(
@@ -1000,6 +1003,7 @@ export default function GazeObservationApp() {
 
     loadStandards(controller.signal);
     loadDelayReasons(controller.signal);
+    loadObservationReasons(controller.signal);
     loadTeamMembers(controller.signal);
 
     return () => {
@@ -1582,10 +1586,11 @@ export default function GazeObservationApp() {
                   className="w-full p-3 rounded-lg border border-gray-300 bg-white disabled:opacity-70"
                 >
                   <option value="">Select Observation Reason</option>
-                  <option value="performance">Performance Review</option>
-                  <option value="training">Training Assessment</option>
-                  <option value="incident">Incident Follow-up</option>
-                  <option value="routine">Routine Check</option>
+                  {observationReasons.map((reason) => (
+                    <option key={reason.id} value={reason.name}>
+                      {reason.name}
+                    </option>
+                  ))}
                 </select>
               </div>
 
@@ -2368,7 +2373,7 @@ export default function GazeObservationApp() {
             {/* AI Notes Section */}
             <div className="p-5 bg-white rounded-lg border border-gray-300 mb-6">
               <h3 className="text-lg font-semibold mb-4 flex items-center gap-2">
-                <span>Engage.X Leader Notes</span>
+                <span>TLC Leader Notes</span>
                 <div className="bg-blue-100 text-blue-700 px-2 py-1 rounded text-sm">
                   AI Generated
                 </div>

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -88,7 +88,7 @@ export default function GazeObservationApp() {
 
   // Multi-level standard selection state
   const [showStandardDropdown, setShowStandardDropdown] = useState(false);
-  const [selectedOrganization, setSelectedOrganization] = useState("");
+  // const [selectedOrganization, setSelectedOrganization] = useState("");
   const [selectedFacility, setSelectedFacility] = useState("");
   const [selectedDepartment, setSelectedDepartment] = useState("");
   const [selectedArea, setSelectedArea] = useState("");
@@ -2298,8 +2298,8 @@ export default function GazeObservationApp() {
                                       {(isObserving ||
                                         isPumpAssessmentActive) && (
                                         <div className="mt-2 pt-1 border-t border-gray-600 text-center text-gray-400 text-xs">
-                                          Hover over entries to delete • Click ×
-                                          to clear all
+                                          Hover over entries to delete �� Click
+                                          × to clear all
                                         </div>
                                       )}
 

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1626,6 +1626,9 @@ export default function GazeObservationApp() {
                                 setEmployeeId(employee.employeeId);
                                 setShowEmployeeDropdown(false);
                                 setEmployeeSearch("");
+                                loadEmployeePerformanceData(
+                                  employee.employeeId,
+                                );
                                 setShowPreviousObservations(true);
                               }}
                               className="p-3 hover:bg-gray-100 cursor-pointer border-b border-gray-100 last:border-b-0"
@@ -2622,10 +2625,10 @@ export default function GazeObservationApp() {
               </h2>
 
               {(() => {
-                // Get all observations for the employee across all standards
+                // Get dynamic observations for the employee
                 const allObservations =
-                  employeeId && previousObservations[employeeId]
-                    ? Object.values(previousObservations[employeeId]).flat()
+                  employeeId && employeePerformanceData[employeeId]
+                    ? employeePerformanceData[employeeId]
                     : [];
 
                 // Sort by date (newest first) and take the last 5

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -199,17 +199,20 @@ export default function GazeObservationApp() {
   ];
 
   // Helper function to get tag group color
-  const getTagGroupColor = useCallback((tags: string[]) => {
-    if (!tags || tags.length === 0) return null;
-    // Use the first tag to determine group identity, create a simple hash
-    const firstTag = tags[0];
-    const hash = firstTag.split("").reduce((a, b) => {
-      a = (a << 5) - a + b.charCodeAt(0);
-      return a & a;
-    }, 0);
-    const colorIndex = Math.abs(hash) % pastelColors.length;
-    return pastelColors[colorIndex];
-  }, []);
+  const getTagGroupColor = useCallback(
+    (tags: string[]) => {
+      if (!tags || tags.length === 0) return null;
+      // Use the first tag to determine group identity, create a simple hash
+      const firstTag = tags[0];
+      const hash = firstTag.split("").reduce((a, b) => {
+        a = (a << 5) - a + b.charCodeAt(0);
+        return a & a;
+      }, 0);
+      const colorIndex = Math.abs(hash) % pastelColors.length;
+      return pastelColors[colorIndex];
+    },
+    [pastelColors],
+  );
 
   // UI state
   const [showPreviousObservations, setShowPreviousObservations] =
@@ -2298,8 +2301,8 @@ export default function GazeObservationApp() {
                                       {(isObserving ||
                                         isPumpAssessmentActive) && (
                                         <div className="mt-2 pt-1 border-t border-gray-600 text-center text-gray-400 text-xs">
-                                          Hover over entries to delete �� Click
-                                          × to clear all
+                                          Hover over entries to delete • Click ×
+                                          to clear all
                                         </div>
                                       )}
 


### PR DESCRIPTION
This pull request includes several database and type system improvements:

**Database Operations:**
- Added optional `limit` parameter to `getObservationsByUser` function
- Updated observations API route to support userId filtering and limit parameter

**Type System Updates:**
- Changed ID types from `number` to `string` across role and permission interfaces
- Updated permission field name from `resource` to `module`
- Changed user count field from `userRoles` to `user_roles`

**UI Improvements:**
- Replaced hardcoded observation data with dynamic API calls
- Added `loadEmployeePerformanceData` function to fetch real employee observations
- Updated observation reasons to load from API with fallback data
- Renamed "Engage.X Leader Notes" to "TLC Leader Notes"
- Removed unused `selectedOrganization` state variable

**Code Cleanup:**
- Simplified permission ID handling by removing string conversions
- Updated function names to reflect new field naming (resource → module)
- Added proper error handling for API calls with timeout management

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 141`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/neon-verse)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-neon-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>neon-verse</branchName>-->