### PR TITLE
Add tickerQuantity and submittedQuantity to ObservationData

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -157,15 +157,17 @@ model Observation {
 }
 
 model ObservationData {
-  id            String      @id @default(cuid())
-  observationId String
-  uom           String
-  description   String
-  quantity      Int
-  samValue      Float
-  totalSams     Float
-  createdAt     DateTime    @default(now())
-  observation   Observation @relation(fields: [observationId], references: [id], onDelete: Cascade)
+  id                String      @id @default(cuid())
+  observationId     String
+  uom               String
+  description       String
+  quantity          Int
+  tickerQuantity    Int         @default(0)
+  submittedQuantity Int         @default(0)
+  samValue          Float
+  totalSams         Float
+  createdAt         DateTime    @default(now())
+  observation       Observation @relation(fields: [observationId], references: [id], onDelete: Cascade)
 
   @@map("observation_data")
 }


### PR DESCRIPTION
Add two new integer fields to the ObservationData model:
- tickerQuantity: defaults to 0
- submittedQuantity: defaults to 0

Both fields are added after the existing quantity field in the schema.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 143`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/pixel-home)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-pixel-home.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>pixel-home</branchName>-->