### PR TITLE
Add standard version support and fix notes popup

### DIFF
--- a/lib/db-operations.ts
+++ b/lib/db-operations.ts
@@ -470,6 +470,29 @@ export async function getStandardVersionHistory(standardId: number) {
   });
 }
 
+export async function getAllStandardVersionIds(standardId: number) {
+  const standard = await prisma.standard.findUnique({
+    where: { id: standardId },
+  });
+
+  if (!standard) {
+    throw new Error("Standard not found");
+  }
+
+  const baseId = standard.baseStandardId || standardId;
+
+  const versions = await prisma.standard.findMany({
+    where: {
+      OR: [{ id: baseId }, { baseStandardId: baseId }],
+    },
+    select: {
+      id: true,
+    },
+  });
+
+  return versions.map((v) => v.id);
+}
+
 // User operations
 export async function createUser(data: {
   employeeId: string;

--- a/lib/db-operations.ts
+++ b/lib/db-operations.ts
@@ -868,7 +868,9 @@ export async function getObservationsByUser(
 ) {
   const whereClause: any = { userId };
   if (standardId) {
-    whereClause.standardId = standardId;
+    // Get all version IDs for this standard
+    const standardIds = await getAllStandardVersionIds(standardId);
+    whereClause.standardId = { in: standardIds };
   }
 
   return prisma.observation.findMany({

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1768,6 +1768,7 @@ export default function GazeObservationApp() {
                               value={standard}
                               onChange={(e) => {
                                 setStandard(e.target.value);
+                                setIsExplicitStandardSelection(true);
                                 setShowStandardDropdown(false);
                               }}
                               className="w-full p-2 border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-blue-500"

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -534,6 +534,7 @@ export default function GazeObservationApp() {
     setHighlightedTagGroup(new Set());
     setActiveRowIds(new Set());
     setIsDynamicGroupingActive(false);
+    setIsExplicitStandardSelection(false);
   };
 
   const getSelectedStandardDisplay = () => {

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -828,7 +828,7 @@ export default function GazeObservationApp() {
     }));
   };
 
-  const calculateTotalSams = () => {
+  const calculateTotalSams = useCallback(() => {
     const total = rows.reduce(
       (sum, row) =>
         sum +
@@ -836,7 +836,7 @@ export default function GazeObservationApp() {
       0,
     );
     setTotalSams(total);
-  };
+  }, [rows, submittedQuantities]);
 
   // Delay timer functionality
   const startDelay = () => {

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1220,6 +1220,7 @@ export default function GazeObservationApp() {
     setQuantitySubmissionHistory({});
     setTempQuantities({});
     setSubmittedQuantities({});
+    setIsExplicitStandardSelection(false);
   };
 
   // Slide navigation for performance trends

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1450,8 +1450,12 @@ export default function GazeObservationApp() {
       const selectedStd = standards.find((s) => s.id === Number(standard));
       if (selectedStd) {
         loadSelectedStandard(selectedStd.id);
-        // Automatically show standard notes popup when standard is selected
-        if (selectedStd.notes && selectedStd.notes.trim()) {
+        // Only show standard notes popup when standard is explicitly selected by user
+        if (
+          isExplicitStandardSelection &&
+          selectedStd.notes &&
+          selectedStd.notes.trim()
+        ) {
           setShowStandardNotes(true);
         }
         // Reload employee performance data when standard changes
@@ -1460,7 +1464,11 @@ export default function GazeObservationApp() {
         }
       }
     }
-  }, [standard, standards, employeeId]);
+    // Reset the explicit selection flag after processing
+    if (isExplicitStandardSelection) {
+      setIsExplicitStandardSelection(false);
+    }
+  }, [standard, standards, employeeId, isExplicitStandardSelection]);
 
   useEffect(() => {
     calculateTotalSams();

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -105,6 +105,8 @@ export default function GazeObservationApp() {
   const [showPumpFinalizationModal, setShowPumpFinalizationModal] =
     useState(false);
   const [showStandardNotes, setShowStandardNotes] = useState(false);
+  const [isExplicitStandardSelection, setIsExplicitStandardSelection] =
+    useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submissionError, setSubmissionError] = useState("");
   const [submissionSuccess, setSubmissionSuccess] = useState(false);

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -1475,7 +1475,7 @@ export default function GazeObservationApp() {
   useEffect(() => {
     calculateTotalSams();
     syncActiveRowIds();
-  }, [rows, submittedQuantities, syncActiveRowIds]);
+  }, [rows, submittedQuantities, syncActiveRowIds, calculateTotalSams]);
 
   useEffect(() => {
     calculatePerformance();


### PR DESCRIPTION
This pull request adds support for standard versions and fixes the standard notes popup behavior.

**Database Operations Changes:**
- Added `getAllStandardVersionIds()` function to retrieve all version IDs for a standard
- Modified `getObservationsByUser()` to query observations across all versions of a standard using the new function

**Observation Form Changes:**
- Added `isExplicitStandardSelection` state to track when user manually selects a standard
- Modified standard notes popup to only show when user explicitly selects a standard (not on automatic loads)
- Added `useCallback` to `calculateTotalSams` function for performance optimization
- Updated dependency arrays in useEffect hooks to include new callback
- Reset explicit selection flag in form reset functions and after processing standard changes

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 148`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/spark-realm)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-spark-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>spark-realm</branchName>-->