### PR TITLE
Disable autosave for Employee and Delay Tracking dropdowns

### DIFF
--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -168,7 +168,7 @@ export default function GazeObservationApp() {
   // Delay tracking with timer functionality
   const [isDelayActive, setIsDelayActive] = useState(false);
   const [delayStartTime, setDelayStartTime] = useState<number | null>(null);
-  const delayReasonMemory = useDropdownMemory({ key: createDropdownKey('observation-form', 'delayReason') });
+  const delayReasonMemory = useDropdownMemory({ key: createDropdownKey('observation-form', 'delayReason'), disableAutosave: true });
   const [delayReason, setDelayReason] = useState(delayReasonMemory.value);
   const [delays, setDelays] = useState<Delay[]>([]);
   const [delayReasons, setDelayReasons] = useState<

--- a/src/app/observation-form/page.tsx
+++ b/src/app/observation-form/page.tsx
@@ -94,7 +94,7 @@ export default function GazeObservationApp() {
   // Dropdown memory hooks
   const observationReasonMemory = useDropdownMemory({ key: createDropdownKey('observation-form', 'observationReason') });
   const [observationReason, setObservationReason] = useState(observationReasonMemory.value);
-  const employeeMemory = useDropdownMemory({ key: createDropdownKey('observation-form', 'employee') });
+  const employeeMemory = useDropdownMemory({ key: createDropdownKey('observation-form', 'employee'), disableAutosave: true });
   const [employeeId, setEmployeeId] = useState(employeeMemory.value);
   const [standard, setStandard] = useState("");
 

--- a/src/hooks/useDropdownMemory.ts
+++ b/src/hooks/useDropdownMemory.ts
@@ -4,6 +4,7 @@ interface UseDropdownMemoryOptions {
   key: string;
   defaultValue?: string;
   excludeValues?: string[]; // Values to not remember (like empty strings)
+  disableAutosave?: boolean; // Disable localStorage saving completely
 }
 
 export function useDropdownMemory({

--- a/src/hooks/useDropdownMemory.ts
+++ b/src/hooks/useDropdownMemory.ts
@@ -32,7 +32,9 @@ export function useDropdownMemory({
   // Function to update value and save to localStorage
   const updateValue = (newValue: string) => {
     setValue(newValue);
-    
+
+    if (disableAutosave) return;
+
     try {
       if (!excludeValues.includes(newValue)) {
         localStorage.setItem(`dropdown_${key}`, newValue);

--- a/src/hooks/useDropdownMemory.ts
+++ b/src/hooks/useDropdownMemory.ts
@@ -47,6 +47,9 @@ export function useDropdownMemory({
   // Function to clear remembered value
   const clearValue = () => {
     setValue(defaultValue);
+
+    if (disableAutosave) return;
+
     try {
       localStorage.removeItem(`dropdown_${key}`);
     } catch (error) {

--- a/src/hooks/useDropdownMemory.ts
+++ b/src/hooks/useDropdownMemory.ts
@@ -10,7 +10,8 @@ interface UseDropdownMemoryOptions {
 export function useDropdownMemory({
   key,
   defaultValue = '',
-  excludeValues = ['']
+  excludeValues = [''],
+  disableAutosave = false
 }: UseDropdownMemoryOptions) {
   const [value, setValue] = useState<string>(defaultValue);
 

--- a/src/hooks/useDropdownMemory.ts
+++ b/src/hooks/useDropdownMemory.ts
@@ -17,6 +17,8 @@ export function useDropdownMemory({
 
   // Load remembered value on mount
   useEffect(() => {
+    if (disableAutosave) return;
+
     try {
       const remembered = localStorage.getItem(`dropdown_${key}`);
       if (remembered && !excludeValues.includes(remembered)) {
@@ -25,7 +27,7 @@ export function useDropdownMemory({
     } catch (error) {
       console.warn(`Failed to load dropdown memory for ${key}:`, error);
     }
-  }, [key, excludeValues]);
+  }, [key, excludeValues, disableAutosave]);
 
   // Function to update value and save to localStorage
   const updateValue = (newValue: string) => {


### PR DESCRIPTION
## Purpose

The user requested to disable the autosave functionality for specific dropdown menus in the observation form. They wanted to prevent the Employee dropdown and Delay Tracking dropdown from automatically saving their values to localStorage while maintaining the dropdown memory functionality for other dropdowns.

## Code changes

- **Enhanced `useDropdownMemory` hook**: Added a new `disableAutosave` parameter that prevents localStorage operations when set to `true`
- **Updated Employee dropdown**: Added `disableAutosave: true` to the `employeeMemory` hook configuration
- **Updated Delay Tracking dropdown**: Added `disableAutosave: true` to the `delayReasonMemory` hook configuration
- **Conditional localStorage operations**: Modified the hook to skip loading from and saving to localStorage when autosave is disabled, while preserving all other functionality

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 161`

🔗 [Edit in Builder.io](https://builder.io/app/projects/446e49d2fb5c4fe1b3830aa578d409fe/vortex-nest)

👀 [Preview Link](https://446e49d2fb5c4fe1b3830aa578d409fe-vortex-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>446e49d2fb5c4fe1b3830aa578d409fe</projectId>-->
<!--<branchName>vortex-nest</branchName>-->